### PR TITLE
[harness][specs] Initialization values

### DIFF
--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -2,6 +2,7 @@ from .specs import InKey
 from .specs import SpecKey
 from .specs import VKey
 from .specs import get_flop
+from .specs import get_inits
 from .specs import get_inputs
 from .specs import get_torch_dtype
 from .specs import input_shape
@@ -12,6 +13,7 @@ __all__ = [
     "SpecKey",
     "VKey",
     "get_flop",
+    "get_inits",
     "get_inputs",
     "get_torch_dtype",
     "input_shape",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -10,6 +10,7 @@ class SpecKey(StrEnum):
     """Keys for spec top-level categories."""
 
     INS = "inputs"
+    INITS = "inits"
     V_CI = "ci"
     V_BENCH_CPU = "bench-cpu"
     V_BENCH_GPU = "bench-gpu"
@@ -20,6 +21,12 @@ class InKey(StrEnum):
 
     SHAPE = "shape"
     TYPE = "dtype"
+
+
+class InitKey(StrEnum):
+    """Keys for spec inits fields."""
+
+    DIM = "dim"
 
 
 class VKey(StrEnum):
@@ -54,7 +61,7 @@ def get_torch_dtype(dtype: str) -> torch.dtype:
 
 
 def input_torch_dtype(input: dict) -> torch.dtype:
-    """Get torch data type for an input
+    """Get torch data type for an input.
     Args:
         input: Specs' input entry
     Returns:
@@ -66,7 +73,7 @@ def input_torch_dtype(input: dict) -> torch.dtype:
 def get_inputs(
     variant: dict, inputs: dict, device: torch.device | None = None
 ) -> list[torch.Tensor]:
-    """Get torch tensors for given specs' config
+    """Get torch tensors for given specs' config.
     Args:
         variant: Specs' variant entry
         inputs: Specs' inputs entry
@@ -86,8 +93,26 @@ def get_inputs(
     return vals
 
 
+def get_inits(variant: dict, inits: list[dict]) -> list[object]:
+    """Get initialization values for given specs' config.
+    Args:
+        variant: Specs' variant entry
+        inits: Specs' inits entry
+    Returns:
+        list of initialization values
+    """
+    dims = variant[VKey.DIMS]
+    init_vals = []
+    for init in inits:
+        if InitKey.DIM in init:
+            init_vals.append(dims[init[InitKey.DIM]])
+        else:
+            raise ValueError("Unsupported init value")
+    return init_vals
+
+
 def get_flop(variant: dict) -> float | None:
-    """Get number of floating-point operations for given specs' variant
+    """Get number of floating-point operations for given specs' variant.
     Args:
         variant: Specs' variant entry
     Returns:

--- a/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [BATCH, IN_FEAT]
+    dtype: float32
+
+inits:
+  - dim: IN_FEAT
+  - dim: OUT_FEAT
+
+ci:
+  - params: [X]
+    dims:
+      BATCH: 32
+      IN_FEAT: 128
+      OUT_FEAT: 128
+
+bench-gpu:
+  - params: [X]
+    dims:
+      BATCH: 128
+      IN_FEAT: 2048
+      OUT_FEAT: 2048


### PR DESCRIPTION
Adds a new top-level specs category that allows defining initialization values.
These inits can then be used to, for example, instantiate kernels with specific sizes.

Also adds a level2 KernelBench problem to demonstrate inits usage.