### PR TITLE
[problems] Switch models to f16

### DIFF
--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -6,6 +6,11 @@ inputs:
     shape: [N, N]
     dtype: float16
 
+ci:
+  - params: [A, B]
+    dims:
+      N: 128
+
 bench-cpu:
   - params: [A, B]
     dims:

--- a/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_FEAT
@@ -11,6 +11,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_FEAT: 128
@@ -20,6 +21,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_FEAT: 4096

--- a/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_SIZE
@@ -10,6 +10,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_SIZE: 128
@@ -18,6 +19,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_SIZE: 4096

--- a/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
+++ b/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_FEAT
@@ -13,6 +13,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_FEAT: 128
@@ -24,6 +25,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_FEAT: 4096

--- a/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
+++ b/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_FEAT
@@ -11,6 +11,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_FEAT: 128
@@ -20,6 +21,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_FEAT: 4096

--- a/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_FEAT
@@ -9,6 +9,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_FEAT: 128
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_FEAT: 4096

--- a/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_FEAT
@@ -11,6 +11,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_FEAT: 128
@@ -20,6 +21,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_FEAT: 4096

--- a/problems/specs/KernelBench/level3/1_MLP.yaml
+++ b/problems/specs/KernelBench/level3/1_MLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_SIZE
@@ -10,6 +10,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_SIZE: 128
@@ -18,6 +19,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       IN_SIZE: 4096

--- a/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
+++ b/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_SIZE
@@ -10,6 +10,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_SIZE: 64
@@ -18,6 +19,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       IN_SIZE: 2048

--- a/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
+++ b/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_SIZE
@@ -10,6 +10,7 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_SIZE: 128
@@ -23,6 +24,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       IN_SIZE: 4096

--- a/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
+++ b/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, SEQ_LEN, N_EMBD]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: N_EMBD
@@ -12,17 +12,19 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
-      BATCH: 32
+      BATCH: 8
       MAX_SEQLEN: 256
       SEQ_LEN: 128
-      N_EMBD: 192
+      N_EMBD: 96
       N_HEAD: 2
       ATTN_PDROP: 0.0
       RESID_PDROP: 0.0
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       MAX_SEQLEN: 1024

--- a/problems/specs/KernelBench/level3/4_LeNet5.yaml
+++ b/problems/specs/KernelBench/level3/4_LeNet5.yaml
@@ -1,13 +1,14 @@
 inputs:
   X:
     shape: [BATCH, IN_1, IN_2, IN_3]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: NUM_CLASSES
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 32
       IN_1: 1
@@ -17,6 +18,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 4096
       IN_1: 1

--- a/problems/specs/KernelBench/level3/5_AlexNet.yaml
+++ b/problems/specs/KernelBench/level3/5_AlexNet.yaml
@@ -1,22 +1,24 @@
 inputs:
   X:
     shape: [BATCH, IN_1, IN_2, IN_3]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: NUM_CLASSES
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
-      BATCH: 32
+      BATCH: 1
       IN_1: 3
       IN_2: 224
       IN_3: 224
-      NUM_CLASSES: 5
+      NUM_CLASSES: 2
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 512
       IN_1: 3

--- a/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
+++ b/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: IN_CHANNELS
@@ -14,17 +14,18 @@ inits:
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
-      IN_CHANNELS: 5
-      OUT_1x1: 64
-      REDUCE_3x3: 32
-      OUT_3x3: 70
-      REDUCE_5x5: 16
-      OUT_5x5: 48
-      POOL_PROJ: 64
-      BATCH: 2
-      HEIGHT: 224
-      WIDTH: 224
+      IN_CHANNELS: 2
+      OUT_1x1: 16
+      REDUCE_3x3: 8
+      OUT_3x3: 35
+      REDUCE_5x5: 8
+      OUT_5x5: 24
+      POOL_PROJ: 32
+      BATCH: 1
+      HEIGHT: 112
+      WIDTH: 112
 
 # Disabled due to the error:
 # Condition append_res Failed on void ZeCollector::PostAppendKernelCommandCommon

--- a/problems/specs/KernelBench/level3/9_ResNet18.yaml
+++ b/problems/specs/KernelBench/level3/9_ResNet18.yaml
@@ -1,23 +1,25 @@
 inputs:
   X:
     shape: [IN_1, IN_2, IN_3, IN_4]
-    dtype: float32
+    dtype: float16
 
 inits:
   - dim: NUM_CLASSES
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 2
-      NUM_CLASSES: 8
+      NUM_CLASSES: 4
       IN_1: 2
       IN_2: 3
-      IN_3: 224
-      IN_4: 244
+      IN_3: 112
+      IN_4: 112
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 2
       NUM_CLASSES: 1000


### PR DESCRIPTION
Switches KernelBench models to use float16 data type.
Minor tweaks CI variant sizes to speed up CPU execution.