### PR TITLE
Add CSV logging for benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,48 @@ python infra/scripts/run_kernel_bench.py --xpu --bench
 python infra/scripts/run_kernel_bench.py --xpu --triton --bench
 ```
 
+### CSV Logging
+
+Benchmark results can be logged to a CSV file using the `--csv` option:
+
+```bash
+# Log results to CSV
+python infra/scripts/run_kernel_bench.py --xpu --triton --bench --csv results.csv
+
+# Add a note to identify the run
+python infra/scripts/run_kernel_bench.py --xpu --triton --bench --csv results.csv --note "BMG card test"
+```
+
+The CSV file includes the following columns:
+- `kernel_name`: Name of the kernel
+- `kernel_type`: Backend used (pytorch/triton)
+- `problem_level`: KernelBench problem level
+- `flops`: Number of floating-point operations
+- `flops_val`: Computed FLOPS value
+- `flops_unit`: FLOPS unit (GFLOPS/TFLOPS)
+- `time_us`: Execution time in microseconds
+- `input_values`: Input dimensions as JSON
+- `note`: User-provided note
+
+Additionally, any environment variables prefixed with `AIBENCH_` are automatically captured and included in the CSV output. This is useful for recording system configuration:
+
+```bash
+# Set environment variables for tracking
+export AIBENCH_CARD="BMG"
+export AIBENCH_SYSTEM="TestRig1"
+python infra/scripts/run_kernel_bench.py --xpu --triton --bench --csv results.csv
+```
+
+### Command Line Options
+
+| Option | Description |
+|--------|-------------|
+| `--xpu` | Run on Intel XPU (default: CPU) |
+| `--triton` | Use Triton backend (default: PyTorch) |
+| `--bench` | Run benchmarks with timing (default: CI validation) |
+| `--csv PATH` | Log results to specified CSV file |
+| `--note TEXT` | Add a note to CSV output for identifying runs |
+
 ## Testing
 
 Run tests with pytest:

--- a/ai_bench/utils/csv_logger.py
+++ b/ai_bench/utils/csv_logger.py
@@ -1,0 +1,24 @@
+import csv
+import os
+
+
+class CSVLogger:
+    def __init__(self, csv_path, fieldnames):
+        self.csv_path = csv_path
+        self.fieldnames = fieldnames
+        self._ensure_header()
+
+    def _ensure_header(self):
+        write_header = True
+        if os.path.isfile(self.csv_path):
+            with open(self.csv_path, "r", newline="") as csvfile:
+                write_header = csvfile.read(1) == ""
+        if write_header:
+            with open(self.csv_path, "w", newline="") as csvfile:
+                writer = csv.DictWriter(csvfile, fieldnames=self.fieldnames)
+                writer.writeheader()
+
+    def log(self, row):
+        with open(self.csv_path, "a", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=self.fieldnames)
+            writer.writerow(row)

--- a/ai_bench/utils/logger.py
+++ b/ai_bench/utils/logger.py
@@ -1,0 +1,12 @@
+import logging
+
+
+def setup_logger(name="ai_bench", level=logging.INFO):
+    logger = logging.getLogger(name)
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -31,6 +31,8 @@ def main(args):
         spec_type=spec_type,
         device=device,
         backend=backend,
+        csv_path=args.csv,
+        note=args.note,
     )
     kb_runner.run_kernels()
 
@@ -60,6 +62,21 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Benchmark execution (default: CI validation)",
+    )
+
+    # CSV logging options.
+    parser.add_argument(
+        "--csv",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Path to CSV file for logging results",
+    )
+    parser.add_argument(
+        "--note",
+        type=str,
+        default="",
+        help="Optional note to include in CSV output",
     )
 
     args = parser.parse_args()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,88 @@
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+from ai_bench.harness import core as ai_hc
+from ai_bench.harness.runner import KernelBenchRunner
+
+
+@pytest.fixture
+def temp_csv_file():
+    os.makedirs("tests/output", exist_ok=True)
+    csv_path = "tests/output/test_logging.csv"
+    if os.path.exists(csv_path):
+        os.remove(csv_path)
+    yield csv_path
+    if os.path.exists(csv_path):
+        os.remove(csv_path)
+
+
+def _create_spec_file(specs_dir, name, content):
+    specs_dir = Path(specs_dir)
+    specs_dir.mkdir(parents=True, exist_ok=True)
+    (specs_dir / name).write_text(content)
+
+
+def _create_kernel_file(kernels_dir, name, content):
+    kernels_dir = Path(kernels_dir)
+    kernels_dir.mkdir(parents=True, exist_ok=True)
+    (kernels_dir / name).write_text(content)
+
+
+def test_csv_logging_and_env_capture(monkeypatch, temp_csv_file):
+    root_dir = Path("tests/output/project_root")
+    spec_dir = root_dir / "problems" / "specs" / "KernelBench" / "level1"
+    kernel_dir = root_dir / "third_party" / "KernelBench" / "KernelBench" / "level1"
+
+    spec_content = """
+inputs:
+  X:
+    shape: [N]
+    dtype: float32
+bench-cpu:
+  - params: [X]
+    dims:
+      N: 4
+    flop: 8*N
+"""
+    kernel_content = """
+import torch
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x):
+        return x * 2
+"""
+
+    _create_spec_file(spec_dir, "double.yaml", spec_content)
+    _create_kernel_file(kernel_dir, "double.py", kernel_content)
+
+    # Patch project_root to use our test root (as a Path!)
+    monkeypatch.setattr("ai_bench.utils.finder.project_root", lambda: root_dir)
+
+    monkeypatch.setenv("AIBENCH_CARD", "D770")
+    monkeypatch.setenv("AIBENCH_SYSTEM", "TestSystem")
+
+    runner = KernelBenchRunner(
+        spec_type=ai_hc.SpecKey.V_BENCH_CPU,
+        device=torch.device("cpu"),
+        backend=ai_hc.Backend.PYTORCH,
+        csv_path=temp_csv_file,
+        note="Unit test note",
+    )
+    runner.run_kernels()
+
+    assert os.path.exists(temp_csv_file), f"CSV file was not created: {temp_csv_file}"
+
+    import csv
+
+    with open(temp_csv_file, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert len(rows) > 0, "No rows were logged to the CSV file"
+    row = rows[0]
+    assert row.get("note") == "Unit test note"
+    assert row.get("AIBENCH_CARD") == "D770"
+    assert row.get("AIBENCH_SYSTEM") == "TestSystem"


### PR DESCRIPTION
Add CSV logging support to capture benchmark results for analysis and comparison.

**Changes:**
- Replace print statements with proper logging using `setup_logger()`
- Add `CSVLogger` utility class for writing results to CSV files
- Add `--csv` and `--note` CLI options to `run_kernel_bench.py`
- Automatically capture `AIBENCH_*` environment variables in CSV output
- Update README with CSV logging documentation

**Usage:**
```bash
python infra/scripts/run_kernel_bench.py --xpu --triton --bench --csv results.csv --note "test run"
```