### PR TITLE
[utils] Flop counter

### DIFF
--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -154,7 +154,11 @@ class KernelBenchRunner:
                     meas = testing.time(
                         fn, args, warmup=self.warmup, rep=self.rep, device=self.device
                     )
+
                     flop = ai_hc.get_flop(variant)
+                    if not flop and self.backend == ai_hc.Backend.PYTORCH:
+                        flop = ai_utils.count_torch_flop(fn, args)
+
                     flops_val = ""
                     flops_unit = ""
                     if flop:

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -4,9 +4,11 @@ from .finder import kernel_bench_dir
 from .finder import project_root
 from .finder import specs
 from .finder import triton_kernels_dir
+from .flop_counter import count_torch_flop
 from .importer import import_from_path
 
 __all__ = [
+    "count_torch_flop",
     "eval_ast",
     "eval_eq",
     "import_from_path",

--- a/ai_bench/utils/flop_counter.py
+++ b/ai_bench/utils/flop_counter.py
@@ -1,0 +1,19 @@
+from collections.abc import Callable
+
+from torch.utils.flop_counter import FlopCounterMode
+
+
+def count_torch_flop(fn: Callable, args: tuple) -> int:
+    """
+    Estimate total number of floating-point operations in the given function.
+    Only torch operations are supported.
+
+    Args:
+        fn: Function to estimate number of flop
+        args: Arguments to pass to the function
+    Returns:
+        Number of floating-point operations
+    """
+    with FlopCounterMode(display=None, depth=None) as flop_counter:
+        fn(*args)
+        return flop_counter.get_total_flops()

--- a/tests/test_flop_counter.py
+++ b/tests/test_flop_counter.py
@@ -1,0 +1,57 @@
+import torch
+
+from ai_bench import utils as ai_utils
+
+
+class TestFlopCounter:
+    """Tests for flop counter."""
+
+    def test_torch_func_flop(self):
+        """Test flop estimate for plain torch function."""
+
+        def torch_fn(a, b):
+            return torch.matmul(a, b)
+
+        M = 4
+        N = 8
+        K = 32
+        flop_ref = 2 * M * N * K
+
+        a = torch.empty(M, K, dtype=torch.float32)
+        b = torch.empty(K, N, dtype=torch.float32)
+        flop_est = ai_utils.count_torch_flop(torch_fn, [a, b])
+
+        assert flop_ref == flop_est
+        assert isinstance(flop_est, int)
+
+    def test_torch_model_flop(self):
+        """Test flop estimate for a torch model."""
+
+        class Model(torch.nn.Module):
+            def __init__(self, in_size, out_size):
+                super().__init__()
+
+                layers = []
+                layers.append(torch.nn.Linear(in_size, out_size, bias=True))
+                layers.append(torch.nn.ReLU())
+
+                self.network = torch.nn.Sequential(*layers)
+
+            def forward(self, x):
+                return self.network(x)
+
+        BATCH = 4
+        IN_SIZE = 8
+        OUT_SIZE = 16
+
+        # Torch flop counter does not include element-wise operations
+        # like bias addition and ReLU.
+        # For example, see:
+        # https://discuss.pytorch.org/t/should-the-bias-in-a-linear-layer-be-considered-when-estimating-flop/224158
+        flop_ref = 2 * BATCH * IN_SIZE * OUT_SIZE
+
+        x = torch.empty(BATCH, IN_SIZE, dtype=torch.float32)
+        model = Model(IN_SIZE, OUT_SIZE)
+        flop_est = ai_utils.count_torch_flop(model.forward, [x])
+
+        assert flop_ref == flop_est


### PR DESCRIPTION
Adds flop counter for torch models.

The counter is used as a fallback estimation if manual flop equation is not provided by a problem spec.