### PR TITLE
Add warning for input/variant dtype mismatch

### DIFF
--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 from typing import Dict
+import warnings
 
 import torch
 
@@ -89,12 +90,20 @@ def get_inputs(
         list of torch tensors
     """
     dims = variant[VKey.DIMS]
+    variant_dtype = get_variant_torch_dtype(variant)
     vals = []
     for param in variant[VKey.PARAMS]:
         input = inputs[param]
         assert "float" in input[InKey.TYPE], "Only floating type is supported now"
         shape = input_shape(input, dims)
         dtype = input_torch_dtype(input)
+        if variant_dtype is not None and dtype != variant_dtype:
+            warnings.warn(
+                f"Input '{param}' dtype ({dtype}) differs from variant dtype "
+                f"({variant_dtype}). This may cause type mismatches.",
+                UserWarning,
+                stacklevel=2,
+            )
         tensor = torch.randn(shape, dtype=dtype, device=device)
         vals.append(tensor)
     return vals

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,0 +1,63 @@
+"""Tests for dtype mismatch warning between input and variant specs."""
+
+import warnings
+
+import pytest
+import torch
+
+from ai_bench.harness import core as ai_hc
+
+
+class TestDtypeMismatchWarning:
+    """Tests for dtype mismatch warning in get_inputs."""
+
+    def test_warns_on_dtype_mismatch(self):
+        """Test that warning is raised when input dtype differs from variant dtype."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"BATCH": 32, "IN_FEAT": 128},
+            ai_hc.VKey.TYPE: "bfloat16",
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["BATCH", "IN_FEAT"],
+                ai_hc.InKey.TYPE: "float16",
+            },
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+
+            assert len(w) == 1
+            assert issubclass(w[0].category, UserWarning)
+            assert "dtype" in str(w[0].message).lower()
+            assert "float16" in str(w[0].message)
+            assert "bfloat16" in str(w[0].message)
+
+        # Tensor should still be created with input dtype.
+        assert tensors[0].dtype == torch.float16
+
+    def test_no_warning_when_dtypes_match(self):
+        """Test that no warning is raised when input and variant dtypes match."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"N": 64},
+            ai_hc.VKey.TYPE: "float32",
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["N"],
+                ai_hc.InKey.TYPE: "float32",
+            },
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+
+            assert len(w) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds a warning when the input tensor dtype differs from the variant dtype specified in the spec configuration.

Now when a spec defines an input with one dtype (e.g., float16) but the variant specifies a different dtype (e.g., bfloat16), the model gets cast to the variant dtype while inputs retain their original dtype. This silent mismatch can cause runtime errors or unexpected behavior.