### PR TITLE
[harness][runner] Unify FLOPS measurement unit

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -34,7 +34,7 @@ jobs:
           uv sync --extra cpu
 
       - name: Run KernelBench
-        run: uv run ${{ github.workspace }}/infra/scripts/run_kernel_bench.py --bench
+        run: uv run ${{ github.workspace }}/infra/scripts/run_kernel_bench.py --bench --gflops
 
   XPU:
     runs-on: pcl-tiergarten

--- a/ai_bench/harness/runner/__init__.py
+++ b/ai_bench/harness/runner/__init__.py
@@ -1,5 +1,7 @@
+from .kernel_bench_runner import FlopsUnit
 from .kernel_bench_runner import KernelBenchRunner
 
 __all__ = [
+    "FlopsUnit",
     "KernelBenchRunner",
 ]

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -27,10 +27,16 @@ def main(args):
         else:
             spec_type = core.SpecKey.V_BENCH_CPU
 
+    if args.gflops:
+        flops_unit = runner.FlopsUnit.GFLOPS
+    else:
+        flops_unit = runner.FlopsUnit.TFLOPS
+
     kb_runner = runner.KernelBenchRunner(
         spec_type=spec_type,
         device=device,
         backend=backend,
+        flops_unit=flops_unit,
         csv_path=args.csv,
         note=args.note,
     )
@@ -62,6 +68,14 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Benchmark execution (default: CI validation)",
+    )
+
+    # Stats options.
+    parser.add_argument(
+        "--gflops",
+        action="store_true",
+        default=False,
+        help="Report GFLOPS (default: TFLOPS)",
     )
 
     # CSV logging options.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from ai_bench.harness import core as ai_hc
-from ai_bench.harness.runner import KernelBenchRunner
+from ai_bench.harness import runner as ai_hr
 from ai_bench.utils.logger import setup_logger
 
 
@@ -67,10 +67,11 @@ class Model(torch.nn.Module):
     monkeypatch.setenv("AIBENCH_CARD", "D770")
     monkeypatch.setenv("AIBENCH_SYSTEM", "TestSystem")
 
-    runner = KernelBenchRunner(
+    runner = ai_hr.KernelBenchRunner(
         spec_type=ai_hc.SpecKey.V_BENCH_CPU,
         device=torch.device("cpu"),
         backend=ai_hc.Backend.PYTORCH,
+        flops_unit=ai_hr.FlopsUnit.TFLOPS,
         csv_path=temp_csv_file,
         note="Unit test note",
     )
@@ -85,6 +86,7 @@ class Model(torch.nn.Module):
         rows = list(reader)
     assert len(rows) > 0, "No rows were logged to the CSV file"
     row = rows[0]
+    assert row.get("flops_unit") == "TFLOPS"
     assert row.get("note") == "Unit test note"
     assert row.get("AIBENCH_CARD") == "D770"
     assert row.get("AIBENCH_SYSTEM") == "TestSystem"


### PR DESCRIPTION
Adds a new enum to control printed FLOPS unit.

Fixed unit helps to avoid confusion when reviewing performance data.
The reported unit can still be controlled with a new flag as using different units (GFLOPS vs TFLOPS) can improve readability between various devices (e.g., CPU vs GPU).

CPU CI benchmark keeps reporting GFLOPS.