### PR TITLE
[harness] PyTorch compile mode backend

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -8,9 +8,13 @@ on:
         type: boolean
         default: false
       RUN_XPU_TORCH:
-        description: "Run on Intel GPU (PyTorch)"
+        description: "Run on Intel GPU (PyTorch eager)"
         type: boolean
         default: true
+      RUN_XPU_TORCH_COMPILE:
+        description: "Run on Intel GPU (PyTorch compile)"
+        type: boolean
+        default: false
       RUN_XPU_TRITON:
         description: "Run on Intel GPU (Triton)"
         type: boolean
@@ -51,6 +55,18 @@ jobs:
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
             '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b torch'"
+
+  XPU-PyTorch-Compile:
+    runs-on: pcl-tiergarten
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.RUN_XPU_TORCH_COMPILE)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Intel Arc B580
+        run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b torch-compile'"
 
   XPU-Triton:
     runs-on: pcl-tiergarten

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ python infra/scripts/run_kernel_bench.py
 # PyTorch on XPU
 python infra/scripts/run_kernel_bench.py --xpu
 
+# PyTorch compile on XPU
+python infra/scripts/run_kernel_bench.py --xpu --torch-compile
+
 # Triton on XPU
 python infra/scripts/run_kernel_bench.py --xpu --triton
 

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -43,6 +43,7 @@ class Backend(StrEnum):
     """Supported backends for kernel execution."""
 
     PYTORCH = "pytorch"
+    PYTORCH_COMPILE = "pytorch-compile"
     TRITON = "triton"
 
 

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -100,10 +100,7 @@ class KernelBenchRunner:
         Returns:
             True if the current backend is torch-based.
         """
-        return (
-            self.backend == ai_hc.Backend.PYTORCH
-            or self.backend == ai_hc.Backend.PYTORCH_COMPILE
-        )
+        return self.backend in [ai_hc.Backend.PYTORCH, ai_hc.Backend.PYTORCH_COMPILE]
 
     def get_spec_dirs(self) -> list[Path]:
         """Get KernelBench level dirs.

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -6,26 +6,27 @@
 
 SCRIPTS_DIR=$(realpath $(dirname $0))
 
+# Backends
+BENCH_BACKEND_TORCH="torch"
+BENCH_BACKEND_TORCH_COMPILE="torch-compile"
+BENCH_BACKEND_TRITON="triton"
+
 die_syntax() {
-  echo "Syntax: $0 [-b (torch|triton)]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
   exit 1
 }
 
-# Backends
-BENCH_BACKEND_TORCH="torch"
-BENCH_BACKEND_TRITON="triton"
-
 # Options
-BENCH_BACKEND="torch"
+BENCH_BACKEND=${BENCH_BACKEND_TORCH}
 while getopts "b:" arg; do
   case ${arg} in
     b)
-      if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ]; then
-        BENCH_BACKEND="${BENCH_BACKEND_TORCH}"
-      elif [ "${OPTARG}" == "${BENCH_BACKEND_TRITON}" ]; then
-        BENCH_BACKEND="${BENCH_BACKEND_TRITON}"
+      if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_TRITON}" ]; then
+        BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
         die_syntax
@@ -57,6 +58,9 @@ echo ""
 echo "--- Run KernelBench (${BENCH_BACKEND})"
 
 BENCH_FLAGS="--xpu --bench"
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"
+fi
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TRITON}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --triton"
 fi

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -58,17 +58,18 @@ if __name__ == "__main__":
     )
 
     # Backend options.
-    parser.add_argument(
+    backend_group = parser.add_mutually_exclusive_group()
+    backend_group.add_argument(
         "--triton",
         action="store_true",
         default=False,
-        help="Use Triton backend (default: PyTorch)",
+        help="Use Triton backend",
     )
-    parser.add_argument(
+    backend_group.add_argument(
         "--torch-compile",
         action="store_true",
         default=False,
-        help="Use PyTorch compile mode (default: eager mode)",
+        help="Use PyTorch compile mode",
     )
 
     # Run mode.

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -17,7 +17,10 @@ def main(args):
     if args.triton:
         backend = core.Backend.TRITON
     else:
-        backend = core.Backend.PYTORCH
+        if args.torch_compile:
+            backend = core.Backend.PYTORCH_COMPILE
+        else:
+            backend = core.Backend.PYTORCH
 
     # Determine spec type.
     spec_type = core.SpecKey.V_CI
@@ -60,6 +63,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Use Triton backend (default: PyTorch)",
+    )
+    parser.add_argument(
+        "--torch-compile",
+        action="store_true",
+        default=False,
+        help="Use PyTorch compile mode (default: eager mode)",
     )
 
     # Run mode.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -413,7 +413,7 @@ class Model(torch.nn.Module):
             )
             assert pytorch_runner.backend == ai_hc.Backend.PYTORCH
 
-            # Run with Triton backend.
+            # Run with PyTorch compile backend.
             pytorch_compile_runner = runner.KernelBenchRunner(
                 spec_type=ai_hc.SpecKey.V_CI,
                 device=torch.device("cpu"),


### PR DESCRIPTION
Adds new backend option to run PyTorch models using 'torch.compile'.

Torch's compile mode can be used to optimize models using TorchDynamo.
This can leads to higher performance thanks to e.g., operator fusion.
The compilation is set to specialize each model for its inputs. That is compiled kernels use static shapes to maximize performance.

The new backend is registered and available through runner scripts and in benchmarking CI job.
