### PR TITLE
[harness] Benchmark memory bandwidth computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The CSV file includes the following columns:
 - `flops`: Number of floating-point operations
 - `flops_val`: Computed FLOPS value
 - `flops_unit`: FLOPS unit (GFLOPS/TFLOPS)
-- `bytes`: Number of bytes transfered - input reads + output writes
+- `mem_bytes`: Number of bytes transfered - input reads + output writes
 - `mem_bw_val`: Computed memory bandwidth value
 - `mem_bw_unit`: Memory bandwidth unit (MB/s or GB/s)
 - `time_us`: Execution time in microseconds

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The CSV file includes the following columns:
 - `flops`: Number of floating-point operations
 - `flops_val`: Computed FLOPS value
 - `flops_unit`: FLOPS unit (GFLOPS/TFLOPS)
+- `bytes`: Number of bytes transfered - input reads + output writes
+- `mem_bw_val`: Computed memory bandwidth value
+- `mem_bw_unit`: Memory bandwidth unit (MB/s or GB/s)
 - `time_us`: Execution time in microseconds
 - `input_values`: Input dimensions as JSON
 - `note`: User-provided note

--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -3,6 +3,7 @@ from .specs import InitKey
 from .specs import InKey
 from .specs import SpecKey
 from .specs import VKey
+from .specs import get_bytes
 from .specs import get_flop
 from .specs import get_inits
 from .specs import get_inputs
@@ -17,6 +18,7 @@ __all__ = [
     "InitKey",
     "SpecKey",
     "VKey",
+    "get_bytes",
     "get_flop",
     "get_inits",
     "get_inputs",

--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -3,10 +3,10 @@ from .specs import InitKey
 from .specs import InKey
 from .specs import SpecKey
 from .specs import VKey
-from .specs import get_bytes
 from .specs import get_flop
 from .specs import get_inits
 from .specs import get_inputs
+from .specs import get_mem_bytes
 from .specs import get_torch_dtype
 from .specs import get_variant_torch_dtype
 from .specs import input_shape
@@ -18,10 +18,10 @@ __all__ = [
     "InitKey",
     "SpecKey",
     "VKey",
-    "get_bytes",
     "get_flop",
     "get_inits",
     "get_inputs",
+    "get_mem_bytes",
     "get_torch_dtype",
     "get_variant_torch_dtype",
     "input_shape",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -37,6 +37,7 @@ class VKey(StrEnum):
     TYPE = "dtype"
     DIMS = "dims"
     FLOP = "flop"
+    BYTES = "bytes"
 
 
 class Backend(StrEnum):
@@ -160,3 +161,25 @@ def get_flop(variant: dict) -> float | None:
     for dim, value in dims.items():
         flop = flop.replace(dim, str(value))
     return utils.eval_eq(flop)
+
+
+def get_bytes(variant: dict) -> float | None:
+    """Get number of memory access bytes for given specs' variant.
+    Args:
+        variant: Specs' variant entry
+    Returns:
+        Number of bytes if available
+    """
+    if VKey.BYTES not in variant:
+        return None
+
+    # Return directly if it is a number.
+    bytes: str | float = variant[VKey.BYTES]
+    if isinstance(bytes, (int, float)):
+        return bytes
+
+    # In case of string equation, evaluate using variant's dimensions.
+    dims = variant[VKey.DIMS]
+    for dim, value in dims.items():
+        bytes = bytes.replace(dim, str(value))
+    return utils.eval_eq(bytes)

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -37,7 +37,7 @@ class VKey(StrEnum):
     TYPE = "dtype"
     DIMS = "dims"
     FLOP = "flop"
-    BYTES = "bytes"
+    MEM_BYTES = "mem_bytes"
 
 
 class Backend(StrEnum):
@@ -163,23 +163,23 @@ def get_flop(variant: dict) -> float | None:
     return utils.eval_eq(flop)
 
 
-def get_bytes(variant: dict) -> float | None:
+def get_mem_bytes(variant: dict) -> float | None:
     """Get number of memory access bytes for given specs' variant.
     Args:
         variant: Specs' variant entry
     Returns:
         Number of bytes if available
     """
-    if VKey.BYTES not in variant:
+    if VKey.MEM_BYTES not in variant:
         return None
 
     # Return directly if it is a number.
-    bytes: str | float = variant[VKey.BYTES]
-    if isinstance(bytes, (int, float)):
-        return bytes
+    mem_bytes: str | float = variant[VKey.MEM_BYTES]
+    if isinstance(mem_bytes, (int, float)):
+        return mem_bytes
 
     # In case of string equation, evaluate using variant's dimensions.
     dims = variant[VKey.DIMS]
     for dim, value in dims.items():
-        bytes = bytes.replace(dim, str(value))
-    return utils.eval_eq(bytes)
+        mem_bytes = mem_bytes.replace(dim, str(value))
+    return utils.eval_eq(mem_bytes)

--- a/ai_bench/harness/runner/__init__.py
+++ b/ai_bench/harness/runner/__init__.py
@@ -1,7 +1,9 @@
 from .kernel_bench_runner import FlopsUnit
 from .kernel_bench_runner import KernelBenchRunner
+from .kernel_bench_runner import MemBwUnit
 
 __all__ = [
     "FlopsUnit",
     "KernelBenchRunner",
+    "MemBwUnit",
 ]

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -65,7 +65,7 @@ class KernelBenchRunner:
             "flops",
             "flops_val",
             "flops_unit",
-            "bytes",
+            "mem_bytes",
             "mem_bw_val",
             "mem_bw_unit",
             "time_us",
@@ -218,12 +218,12 @@ class KernelBenchRunner:
                     )
 
                     # Statistics - memory bandwidth.
-                    bytes = ai_hc.get_bytes(variant)
+                    mem_bytes = ai_hc.get_mem_bytes(variant)
 
                     mem_bw_val = ""
                     mem_bw_unit = ""
-                    if bytes:
-                        gbs = bytes / meas_us / 1e3
+                    if mem_bytes:
+                        gbs = mem_bytes / meas_us / 1e3
                         match self.mem_bw_unit:
                             case MemBwUnit.GBS:
                                 mem_bw_val = gbs
@@ -251,7 +251,7 @@ class KernelBenchRunner:
                             "flops": flop if flop is not None else "",
                             "flops_val": flops_val,
                             "flops_unit": flops_unit,
-                            "bytes": bytes if bytes is not None else "",
+                            "mem_bytes": mem_bytes if mem_bytes is not None else "",
                             "mem_bw_val": mem_bw_val,
                             "mem_bw_unit": mem_bw_unit,
                             "time_us": meas_us,

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -189,7 +189,7 @@ class KernelBenchRunner:
                         continue
 
                     self.logger.info(f"Benchmarking: {variant}")
-                    meas = testing.time(
+                    meas_us = testing.time(
                         fn, args, warmup=self.warmup, rep=self.rep, device=self.device
                     )
 
@@ -201,7 +201,7 @@ class KernelBenchRunner:
                     flops_val = ""
                     flops_unit = ""
                     if flop:
-                        tflops = flop / meas / 1e6
+                        tflops = flop / meas_us / 1e6
                         match self.flops_unit:
                             case FlopsUnit.TFLOPS:
                                 flops_val = tflops
@@ -214,7 +214,7 @@ class KernelBenchRunner:
                         flops_unit = str(self.flops_unit)
 
                     self.logger.info(
-                        f"  time [us]: {meas:.6f} {flops_unit}: {flops_val}"
+                        f"  time [us]: {meas_us:.6f} {flops_unit}: {flops_val}"
                     )
 
                     # Statistics - memory bandwidth.
@@ -223,7 +223,7 @@ class KernelBenchRunner:
                     mem_bw_val = ""
                     mem_bw_unit = ""
                     if bytes:
-                        gbs = bytes / meas / 1e9
+                        gbs = bytes / meas_us / 1e3
                         match self.mem_bw_unit:
                             case MemBwUnit.GBS:
                                 mem_bw_val = gbs
@@ -254,7 +254,7 @@ class KernelBenchRunner:
                             "bytes": bytes if bytes is not None else "",
                             "mem_bw_val": mem_bw_val,
                             "mem_bw_unit": mem_bw_unit,
-                            "time_us": meas,
+                            "time_us": meas_us,
                             "input_values": json.dumps(
                                 variant.get(ai_hc.VKey.DIMS, {})
                             ),

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -35,11 +35,17 @@ def main(args):
     else:
         flops_unit = runner.FlopsUnit.TFLOPS
 
+    if args.mbs:
+        mem_bw_unit = runner.MemBwUnit.MBS
+    else:
+        mem_bw_unit = runner.MemBwUnit.GBS
+
     kb_runner = runner.KernelBenchRunner(
         spec_type=spec_type,
         device=device,
         backend=backend,
         flops_unit=flops_unit,
+        mem_bw_unit=mem_bw_unit,
         csv_path=args.csv,
         note=args.note,
     )
@@ -86,6 +92,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Report GFLOPS (default: TFLOPS)",
+    )
+    parser.add_argument(
+        "--mbs",
+        action="store_true",
+        default=False,
+        help="Report MB/s (default: GB/s)",
     )
 
     # CSV logging options.

--- a/problems/specs/KernelBench/level1/19_ReLU.yaml
+++ b/problems/specs/KernelBench/level1/19_ReLU.yaml
@@ -15,7 +15,7 @@ bench-cpu:
       BATCH: 128
       DIM: 2048
     flop: "BATCH*DIM"
-    bytes: "(2*BATCH*DIM) * 2"
+    mem_bytes: "(2*BATCH*DIM) * 2" # f16
 
 bench-gpu:
   - params: [X]
@@ -23,4 +23,4 @@ bench-gpu:
       BATCH: 1024
       DIM: 16384
     flop: "BATCH*DIM"
-    bytes: "(2*BATCH*DIM) * 2"
+    mem_bytes: "(2*BATCH*DIM) * 2" # f16

--- a/problems/specs/KernelBench/level1/19_ReLU.yaml
+++ b/problems/specs/KernelBench/level1/19_ReLU.yaml
@@ -15,6 +15,7 @@ bench-cpu:
       BATCH: 128
       DIM: 2048
     flop: "BATCH*DIM"
+    bytes: "(2*BATCH*DIM) * 2"
 
 bench-gpu:
   - params: [X]
@@ -22,3 +23,4 @@ bench-gpu:
       BATCH: 1024
       DIM: 16384
     flop: "BATCH*DIM"
+    bytes: "(2*BATCH*DIM) * 2"

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -20,6 +20,7 @@ bench-cpu:
       N: 256
       K: 512
     flop: "2*M*N*K"
+    bytes: "(M*K + K*N + M*N) * 2"
 
 bench-gpu:
   - params: [A, B]
@@ -28,3 +29,4 @@ bench-gpu:
       N: 3072
       K: 4096
     flop: "2*M*N*K"
+    bytes: "(M*K + K*N + M*N) * 2"

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -20,7 +20,7 @@ bench-cpu:
       N: 256
       K: 512
     flop: "2*M*N*K"
-    bytes: "(M*K + K*N + M*N) * 2"
+    mem_bytes: "(M*K + K*N + M*N) * 2" # f16
 
 bench-gpu:
   - params: [A, B]
@@ -29,4 +29,4 @@ bench-gpu:
       N: 3072
       K: 4096
     flop: "2*M*N*K"
-    bytes: "(M*K + K*N + M*N) * 2"
+    mem_bytes: "(M*K + K*N + M*N) * 2" # f16

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -132,28 +132,28 @@ class TestSpecFunctions:
 
         assert ai_hc.get_flop(variant) is None
 
-    def test_get_bytes_numeric(self):
-        """Test bytes extraction with numeric value."""
-        variant = {ai_hc.VKey.BYTES: 16384}
+    def test_get_mem_bytes_numeric(self):
+        """Test memory bytes extraction with numeric value."""
+        variant = {ai_hc.VKey.MEM_BYTES: 16384}
 
-        assert ai_hc.get_bytes(variant) == 16384
+        assert ai_hc.get_mem_bytes(variant) == 16384
 
-    def test_get_bytes_formula(self):
-        """Test bytes extraction with formula."""
+    def test_get_mem_bytes_formula(self):
+        """Test memory bytes extraction with formula."""
         variant = {
             ai_hc.VKey.DIMS: {"M": 16, "N": 32, "K": 64},
-            ai_hc.VKey.BYTES: "(M*K + K*N + M*N) * 2",
+            ai_hc.VKey.MEM_BYTES: "(M*K + K*N + M*N) * 2",
         }
 
-        bytes = ai_hc.get_bytes(variant)
+        mem_bytes = ai_hc.get_mem_bytes(variant)
 
-        assert bytes == (16 * 64 + 64 * 32 + 16 * 32) * 2
+        assert mem_bytes == (16 * 64 + 64 * 32 + 16 * 32) * 2
 
-    def test_get_bytes_missing(self):
-        """Test bytes extraction when missing."""
+    def test_get_mem_bytes_missing(self):
+        """Test memory bytes extraction when missing."""
         variant = {ai_hc.VKey.DIMS: {"N": 64}}
 
-        assert ai_hc.get_bytes(variant) is None
+        assert ai_hc.get_mem_bytes(variant) is None
 
 
 class TestKernelBenchRunnerInit:
@@ -643,7 +643,7 @@ bench-cpu:
       K: 32
       N: 32
     flop: 2*M*N*K
-    bytes: "(M*K + K*N + M*N) * 4"
+    mem_bytes: "(M*K + K*N + M*N) * 4"
 """
             (specs_dir / "matmul.yaml").write_text(spec)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -132,6 +132,29 @@ class TestSpecFunctions:
 
         assert ai_hc.get_flop(variant) is None
 
+    def test_get_bytes_numeric(self):
+        """Test bytes extraction with numeric value."""
+        variant = {ai_hc.VKey.BYTES: 16384}
+
+        assert ai_hc.get_bytes(variant) == 16384
+
+    def test_get_bytes_formula(self):
+        """Test bytes extraction with formula."""
+        variant = {
+            ai_hc.VKey.DIMS: {"M": 16, "N": 32, "K": 64},
+            ai_hc.VKey.BYTES: "(M*K + K*N + M*N) * 2",
+        }
+
+        bytes = ai_hc.get_bytes(variant)
+
+        assert bytes == (16 * 64 + 64 * 32 + 16 * 32) * 2
+
+    def test_get_bytes_missing(self):
+        """Test bytes extraction when missing."""
+        variant = {ai_hc.VKey.DIMS: {"N": 64}}
+
+        assert ai_hc.get_bytes(variant) is None
+
 
 class TestKernelBenchRunnerInit:
     """Tests for KernelBenchRunner initialization."""
@@ -620,6 +643,7 @@ bench-cpu:
       K: 32
       N: 32
     flop: 2*M*N*K
+    bytes: "(M*K + K*N + M*N) * 4"
 """
             (specs_dir / "matmul.yaml").write_text(spec)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,7 +48,7 @@ bench-cpu:
     dims:
       N: 4
     flop: 8*N
-    bytes: N + N
+    mem_bytes: (N + N) * 4 # f32
 """
     kernel_content = """
 import torch

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -48,6 +48,7 @@ bench-cpu:
     dims:
       N: 4
     flop: 8*N
+    bytes: N + N
 """
     kernel_content = """
 import torch
@@ -72,6 +73,7 @@ class Model(torch.nn.Module):
         device=torch.device("cpu"),
         backend=ai_hc.Backend.PYTORCH,
         flops_unit=ai_hr.FlopsUnit.TFLOPS,
+        mem_bw_unit=ai_hr.MemBwUnit.GBS,
         csv_path=temp_csv_file,
         note="Unit test note",
     )
@@ -87,6 +89,7 @@ class Model(torch.nn.Module):
     assert len(rows) > 0, "No rows were logged to the CSV file"
     row = rows[0]
     assert row.get("flops_unit") == "TFLOPS"
+    assert row.get("mem_bw_unit") == "GB/s"
     assert row.get("note") == "Unit test note"
     assert row.get("AIBENCH_CARD") == "D770"
     assert row.get("AIBENCH_SYSTEM") == "TestSystem"


### PR DESCRIPTION
Adds an optional 'mem_bytes' problem spec field that allows specifying number of memory access bytes required for roofline model analysis.

Similarly to floating-point operations, the memory accesses can be expressed as an equation and parametrized with inputs' dimensions.