### PR TITLE
[utils] Memory access counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ The CSV file includes the following columns:
 - `flops_val`: Computed FLOPS value
 - `flops_unit`: FLOPS unit (GFLOPS/TFLOPS)
 - `flops_note`: FLOPS measurement annotation (see 'Notes legend')
-- `mem_bytes`: Number of bytes transferred - input reads + output writes
+- `mem_bytes`: Number of memory bytes transferred - input reads + output writes
 - `mem_bw_val`: Computed memory bandwidth value
 - `mem_bw_unit`: Memory bandwidth unit (MB/s or GB/s)
+- `mem_note`: Memory measurement annotation (see 'Notes legend')
 - `time_us`: Execution time in microseconds
 - `input_values`: Input dimensions as JSON
 - `note`: User-provided note

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -76,6 +76,7 @@ class KernelBenchRunner:
             "mem_bytes",
             "mem_bw_val",
             "mem_bw_unit",
+            "mem_note",
             "time_us",
             "input_values",
             "note",
@@ -191,7 +192,10 @@ class KernelBenchRunner:
                 for variant in variants:
                     model_inits = ai_hc.get_inits(variant, inits)
                     model_dtype = ai_hc.get_variant_torch_dtype(variant)
-                    model = model_obj(*model_inits).to(self.device, dtype=model_dtype)
+                    base_model = model_obj(*model_inits).to(
+                        self.device, dtype=model_dtype
+                    )
+                    model = base_model
 
                     if self.backend == ai_hc.Backend.PYTORCH_COMPILE:
                         model = torch.compile(model, dynamic=False)
@@ -241,9 +245,14 @@ class KernelBenchRunner:
 
                     # Statistics - memory bandwidth.
                     mem_bytes = ai_hc.get_mem_bytes(variant)
+                    mem_is_estimate = False
+                    if not mem_bytes and self.is_torch_backend():
+                        mem_bytes = ai_utils.count_torch_memory_bytes(base_model, args)
+                        mem_is_estimate = True
 
                     mem_bw_val = ""
                     mem_bw_unit = ""
+                    mem_note = ""
                     if mem_bytes:
                         gbs = mem_bytes / meas_us / 1e3
                         match self.mem_bw_unit:
@@ -255,10 +264,11 @@ class KernelBenchRunner:
                                 raise ValueError(
                                     f"Invalid memory bandwidth unit: {self.mem_bw_unit}"
                                 )
-
                         mem_bw_unit = str(self.mem_bw_unit)
+                        if mem_is_estimate:
+                            mem_note = NotesSymbols.ESTIMATE
 
-                        self.logger.info(f"  {mem_bw_unit}: {mem_bw_val}")
+                        self.logger.info(f"  {mem_bw_unit}: {mem_bw_val} {mem_note}")
 
                     if self.csv_logger:
                         aibench_env = {
@@ -277,6 +287,7 @@ class KernelBenchRunner:
                             "mem_bytes": mem_bytes if mem_bytes is not None else "",
                             "mem_bw_val": mem_bw_val,
                             "mem_bw_unit": mem_bw_unit,
+                            "mem_note": mem_note,
                             "time_us": meas_us,
                             "input_values": json.dumps(
                                 variant.get(ai_hc.VKey.DIMS, {})

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -9,11 +9,15 @@ from .finder import specs
 from .finder import triton_kernels_dir
 from .flop_counter import count_torch_flop
 from .importer import import_from_path
+from .memory_counter import MemoryCounter
+from .memory_counter import count_torch_memory_bytes
 
 __all__ = [
     "ConfigurationError",
+    "MemoryCounter",
     "configure",
     "count_torch_flop",
+    "count_torch_memory_bytes",
     "eval_ast",
     "eval_eq",
     "import_from_path",

--- a/ai_bench/utils/memory_counter.py
+++ b/ai_bench/utils/memory_counter.py
@@ -1,0 +1,190 @@
+from collections import defaultdict
+from pprint import pprint
+from typing import Callable
+from typing import Dict
+
+import torch
+import torch.nn as nn
+from torch.utils.hooks import RemovableHandle
+
+
+class MemoryCounter:
+    """
+    Context manager that manages memory counting state and holds a summary of results.
+
+    Internally, it counts ideal number of memory transfers through module hooks by tracking
+    tensors accessed: inputs, fixed parameters (reads) and results (writes).
+
+    The module should be invocated directly within the memory counter context to trigger all
+    registered counting hooks.
+
+    Args:
+        module: PyTorch module for tracking
+
+    Example:
+        mod = torch.nn.Linear(2, 2)
+
+        with MemoryCounter(mod) as mem_count:
+            mod(torch.randn(2, 2))
+
+        bytes = mem_count.get_total_bytes()
+    """
+
+    def __init__(self, module: nn.Module):
+        self.module: nn.Module = module
+        self.memory_stats = defaultdict(lambda: {"reads": 0, "writes": 0, "shapes": []})
+        self.hooks: list[RemovableHandle] = []
+
+    # Clears previous measurements on reentry.
+    def __enter__(self):
+        self._reset_stats()
+        self._register_hooks()
+
+        # Gather static module information.
+        # It is assumed that these special module attributes
+        # are loaded only once.
+        reads = 0
+        shapes = []
+
+        # Count reads from all parameters.
+        for param in self.module.parameters(recurse=True):
+            if isinstance(param, torch.Tensor):
+                reads += self._get_tensor_memory_size(param)
+                shapes.append(param.size())
+        # Count reads from all buffers.
+        for buffer in self.module.buffers(recurse=True):
+            if isinstance(buffer, torch.Tensor):
+                reads += self._get_tensor_memory_size(buffer)
+                shapes.append(buffer.size())
+
+        # Store top-level statistics.
+        self.memory_stats[self.module._get_name()]["reads"] += reads
+        self.memory_stats[self.module._get_name()]["shapes"].append(shapes)
+
+        return self
+
+    def __exit__(self, *args):
+        self._remove_hooks()
+
+    def get_total_bytes(self) -> int:
+        """Get total number of memory access bytes."""
+        stats = self.get_total_stats()
+        return stats["total_memory_bytes"]
+
+    def get_total_stats(self) -> Dict[str, int]:
+        """Get memory statistics summary across all modules."""
+        total_reads = sum(stats["reads"] for stats in self.memory_stats.values())
+        total_writes = sum(stats["writes"] for stats in self.memory_stats.values())
+
+        return {
+            "total_reads_bytes": total_reads,
+            "total_writes_bytes": total_writes,
+            "total_memory_bytes": total_reads + total_writes,
+        }
+
+    def print_memory_report(self):
+        """Print a formatted memory counter report."""
+        total_stats = self.get_total_stats()
+
+        print("=" * 50)
+        print("MEMORY TRACKING REPORT")
+        print("=" * 50)
+        print(
+            f"Total Reads:  {total_stats['total_reads_bytes']:,} bytes ({total_stats['total_reads_bytes'] / 1024**2:.2f} MB)"
+        )
+        print(
+            f"Total Writes: {total_stats['total_writes_bytes']:,} bytes ({total_stats['total_writes_bytes'] / 1024**2:.2f} MB)"
+        )
+        print(
+            f"Total Memory: {total_stats['total_memory_bytes']:,} bytes ({total_stats['total_memory_bytes'] / 1024**2:.2f} MB)"
+        )
+        print("=" * 50)
+
+        print("\nPER-MODULE BREAKDOWN:")
+        print("-" * 50)
+        print(f"{'Module':<15} | {'Reads (MB)':<15} | {'Writes (MB)':<15}")
+        print("-" * 50)
+        for name, stats in self.memory_stats.items():
+            reads_mb = stats["reads"] / 1024**2
+            writes_mb = stats["writes"] / 1024**2
+            print(f"{name:<15} | {reads_mb:<15.2f} | {writes_mb:<15.2f}")
+
+        print("")
+        for name, stats in self.memory_stats.items():
+            print(f"Module {name} - shapes:")
+            for shape in stats["shapes"]:
+                pprint(shape, compact=True)
+
+    def _get_tensor_memory_size(self, tensor: torch.Tensor) -> int:
+        """Calculate memory size in bytes for a tensor."""
+        return tensor.numel() * tensor.element_size()
+
+    def _create_hook(self, name: str) -> Callable:
+        """Create a hook function for a specific module."""
+
+        def hook_fn(module: nn.Module, inputs, outputs) -> Callable:
+            reads = 0
+            writes = 0
+            shapes = []
+
+            # Count reads from inputs.
+            if isinstance(inputs, (tuple, list)):
+                for tensor in inputs:
+                    if isinstance(tensor, torch.Tensor):
+                        reads += self._get_tensor_memory_size(tensor)
+                        shapes.append(tensor.size())
+            elif isinstance(inputs, torch.Tensor):
+                reads += self._get_tensor_memory_size(inputs)
+                shapes.append(inputs.size())
+
+            # Count writes to outputs.
+            if isinstance(outputs, (tuple, list)):
+                for tensor in outputs:
+                    if isinstance(tensor, torch.Tensor):
+                        writes += self._get_tensor_memory_size(tensor)
+                        shapes.append(tensor.size())
+            elif isinstance(outputs, torch.Tensor):
+                writes += self._get_tensor_memory_size(outputs)
+                shapes.append(outputs.size())
+
+            # Store statistics.
+            self.memory_stats[name]["reads"] += reads
+            self.memory_stats[name]["writes"] += writes
+            self.memory_stats[name]["shapes"].append(shapes)
+
+        return hook_fn
+
+    def _register_hooks(self):
+        """Register hooks for all modules in the model."""
+        for name, mod in self.module.named_modules():
+            # Only track leaf modules.
+            if len(list(mod.children())) == 0:
+                hook = mod.register_forward_hook(self._create_hook(name))
+                self.hooks.append(hook)
+
+    def _remove_hooks(self):
+        """Remove all registered hooks."""
+        for hook in self.hooks:
+            hook.remove()
+        self.hooks.clear()
+
+    def _reset_stats(self):
+        """Reset all statistics."""
+        self.memory_stats.clear()
+
+
+def count_torch_memory_bytes(module: nn.Module, args: tuple) -> int:
+    """
+    Estimate total number of memory access bytes (reads + writes)
+    in the given PyTorch module.
+
+    Args:
+        module: PyTorch module for estimation
+        args: Arguments to pass to the module
+    Returns:
+        Number of memory access bytes
+    """
+    # Disable gradient as only forward inference passes are considered.
+    with torch.no_grad(), MemoryCounter(module) as mem_count:
+        module(*args)
+    return mem_count.get_total_bytes()

--- a/ai_bench/utils/memory_counter.py
+++ b/ai_bench/utils/memory_counter.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from pprint import pprint
 from typing import Callable
 from typing import Dict
 
@@ -84,6 +83,8 @@ class MemoryCounter:
 
     def print_memory_report(self):
         """Print a formatted memory counter report."""
+        from pprint import pprint
+
         total_stats = self.get_total_stats()
 
         print("=" * 50)

--- a/ai_bench/utils/memory_counter.py
+++ b/ai_bench/utils/memory_counter.py
@@ -122,7 +122,7 @@ class MemoryCounter:
     def _create_hook(self, name: str) -> Callable:
         """Create a hook function for a specific module."""
 
-        def hook_fn(module: nn.Module, inputs, outputs) -> Callable:
+        def hook_fn(module: nn.Module, inputs, outputs) -> None:
             reads = 0
             writes = 0
             shapes = []

--- a/tests/test_memory_counter.py
+++ b/tests/test_memory_counter.py
@@ -1,0 +1,164 @@
+import torch
+from torch import nn
+
+from ai_bench import utils as ai_utils
+
+
+class TestMemoryCounter:
+    """Tests for memory counter."""
+
+    def test_torch_function_wrapper_model(self):
+        """Test memory count for module wrapping a function."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+
+            def forward(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+                return torch.matmul(a, b)
+
+        M = 4
+        N = 8
+        K = 16
+
+        mod = Model()
+        a = torch.empty(M, K, dtype=torch.float32)
+        b = torch.empty(K, N, dtype=torch.float32)
+
+        bytes_ref = (
+            M * K
+            + K * N  # Inputs
+            + M * N  # Result
+        ) * a.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [a, b])
+
+        assert bytes_ref == mem_bytes
+        assert isinstance(mem_bytes, int)
+
+    def test_torch_model_with_internal_params(self):
+        """Test memory count for module with internal parameters."""
+
+        BATCH = 4
+        IN_FEAT = 8
+        OUT_FEAT = 16
+
+        mod = nn.Linear(IN_FEAT, OUT_FEAT, bias=True)
+        x = torch.empty(BATCH, IN_FEAT, dtype=torch.float32)
+
+        bytes_ref = (
+            BATCH * IN_FEAT  # Input
+            + IN_FEAT * OUT_FEAT  # Weight
+            + OUT_FEAT  # Bias
+            + BATCH * OUT_FEAT  # Result
+        ) * x.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [x])
+
+        assert bytes_ref == mem_bytes
+
+    def test_torch_functional_wrapper_model(self):
+        """Test memory count for modele wrapping a torch stateless network."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+
+            def forward(
+                self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+            ) -> torch.Tensor:
+                return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+        Z = 2
+        H = 4
+        N_CTX = 8
+        D_HEAD = 16
+
+        mod = Model()
+        q = torch.rand(Z, H, N_CTX, D_HEAD, dtype=torch.bfloat16)
+        k = torch.rand(Z, H, N_CTX, D_HEAD, dtype=torch.bfloat16)
+        v = torch.rand(Z, H, N_CTX, D_HEAD, dtype=torch.bfloat16)
+
+        bytes_ref = (2 * Z * H * (N_CTX * D_HEAD + N_CTX * D_HEAD)) * q.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [q, k, v])
+
+        assert bytes_ref == mem_bytes
+
+    def test_torch_model_multiple_outputs(self):
+        """Test memory count for module with mutliple results."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+
+            def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+                val = torch.add(x, x)
+                return val, val
+
+        M = 4
+        N = 8
+
+        mod = Model()
+        x = torch.empty(M, N, dtype=torch.float32)
+
+        bytes_ref = (3 * M * N) * x.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [x])
+
+        assert bytes_ref == mem_bytes
+        assert isinstance(mem_bytes, int)
+
+    def test_torch_model_multiple_layers(self):
+        """Test memory count for module with mutliple layers."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+
+                self.network = nn.Sequential(
+                    nn.Linear(4, 8, bias=False), nn.ReLU(), nn.Linear(8, 2, bias=True)
+                )
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                return self.network(x)
+
+        M = 16
+
+        mod = Model()
+        x = torch.empty(M, 4, dtype=torch.float32)
+
+        bytes_ref = (
+            (M * 4 + 4 * 8 + M * 8)  # Linear without bias
+            + (M * 8 + M * 8)  # ReLU
+            + (M * 8 + 8 * 2 + 2 + M * 2)  # Linear with bias
+        ) * x.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [x])
+
+        assert bytes_ref == mem_bytes
+
+    def test_torch_model_with_params_and_buffers(self):
+        """Test memory count for module with parameters and buffers."""
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.matmul = nn.Linear(4, 8, bias=False)
+                self.add_value = nn.Parameter(torch.randn(8))
+                self.sub_value = nn.Buffer(torch.randn(8))
+
+            def forward(self, x):
+                x = self.matmul(x)
+                x = x + self.add_value
+                x = x - self.sub_value
+                return x
+
+        M = 16
+
+        mod = Model()
+        x = torch.empty(M, 4, dtype=torch.float32)
+
+        bytes_ref = (
+            (M * 4 + 4 * 8 + M * 8)  # Linear without bias
+            + (8)  # Parameter
+            + (8)  # Buffer
+        ) * x.element_size()
+        mem_bytes = ai_utils.count_torch_memory_bytes(mod, [x])
+
+        assert bytes_ref == mem_bytes


### PR DESCRIPTION
Adds memory counter for PyTorch models.

The counter estimates ideal number memory accesses (reads and writes) used for memory bandwidth computation.

The counter is used as a fallback when manual bytes equation is not provided by a problem spec.