### PR TITLE
[harness] Helion backend

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -19,6 +19,10 @@ on:
         description: "Run on Intel GPU (Triton)"
         type: boolean
         default: false
+      RUN_XPU_HELION:
+        description: "Run on Intel GPU (Helion)"
+        type: boolean
+        default: false
 
 env:
   NPROCS_LIMIT_LINK: 8
@@ -79,3 +83,15 @@ jobs:
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
             '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b triton'"
+
+  XPU-Helion:
+    runs-on: pcl-tiergarten
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.RUN_XPU_HELION)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Intel Arc B580
+        run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b helion'"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![KernelBench Perf](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml/badge.svg)](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml)
 ![Status](https://img.shields.io/badge/status-beta-yellow)
 
-A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton) and devices (CPU, XPU).
+A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion) and devices (CPU, XPU).
 
 ## Installation
 
@@ -49,6 +49,9 @@ ai-bench --xpu --torch-compile
 # Triton on XPU
 ai-bench --xpu --triton
 
+# Helion on XPU
+ai-bench --xpu --helion
+
 # Benchmark mode (with timing)
 ai-bench --xpu --bench
 
@@ -72,6 +75,9 @@ python infra/scripts/run_kernel_bench.py --xpu --torch-compile
 
 # Triton on XPU
 python infra/scripts/run_kernel_bench.py --xpu --triton
+
+# Helion on XPU
+python infra/scripts/run_kernel_bench.py --xpu --helion
 
 # Benchmark mode (with timing)
 python infra/scripts/run_kernel_bench.py --xpu --bench
@@ -188,6 +194,7 @@ Environment variables used for project configuration:
 | `AIBENCH_SPECS_DIR` | Path to specs directory |
 | `AIBENCH_KERNELS_DIR` | Path to PyTorch kernels directory |
 | `AIBENCH_TRITON_KERNELS_DIR` | Path to Triton kernels directory |
+| `AIBENCH_HELION_KERNELS_DIR` | Path to Helion kernels directory |
 
 ## License
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -95,6 +95,12 @@ Environment file (.env) example:
         default=None,
         help="Path to Triton kernels directory (default: auto-detect or AIBENCH_TRITON_KERNELS_DIR)",
     )
+    path_group.add_argument(
+        "--helion-kernels-dir",
+        type=Path,
+        default=None,
+        help="Path to Helion kernels directory (default: auto-detect or AIBENCH_HELION_KERNELS_DIR)",
+    )
 
     # Device options
     device_group = parser.add_argument_group("device options")

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -32,6 +32,9 @@ Examples:
   # Run with Triton backend
   ai-bench --xpu --bench --triton
 
+  # Run with Helion backend
+  ai-bench --xpu --bench --helion
+
   # Save results to CSV
   ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
@@ -132,6 +135,12 @@ Environment file (.env) example:
         default=False,
         help="Use PyTorch compile mode",
     )
+    backend_exclusive.add_argument(
+        "--helion",
+        action="store_true",
+        default=False,
+        help="Use Helion backend",
+    )
 
     # Run mode
     mode_group = parser.add_argument_group("run mode")
@@ -197,11 +206,17 @@ def main(argv: list[str] | None = None) -> int:
             finder.load_env()  # Auto-detect
 
     # Configure paths if provided
-    if args.specs_dir or args.kernels_dir or args.triton_kernels_dir:
+    if (
+        args.specs_dir
+        or args.kernels_dir
+        or args.triton_kernels_dir
+        or args.helion_kernels_dir
+    ):
         finder.configure(
             specs_dir=args.specs_dir,
             kernels_dir=args.kernels_dir,
             triton_kernels_dir=args.triton_kernels_dir,
+            helion_kernels_dir=args.helion_kernels_dir,
         )
 
     # Determine device
@@ -215,6 +230,8 @@ def main(argv: list[str] | None = None) -> int:
     # Determine backend
     if args.triton:
         backend = core.Backend.TRITON
+    elif args.helion:
+        backend = core.Backend.HELION
     elif args.torch_compile:
         backend = core.Backend.PYTORCH_COMPILE
     else:

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -46,6 +46,7 @@ class Backend(StrEnum):
     PYTORCH = "pytorch"
     PYTORCH_COMPILE = "pytorch-compile"
     TRITON = "triton"
+    HELION = "helion"
 
 
 def input_shape(input_entry: dict, dims: Dict[str, int]) -> list[int]:

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -95,6 +95,8 @@ class KernelBenchRunner:
             self.kernels = ai_utils.kernel_bench_dir() / "KernelBench"
         elif self.backend == ai_hc.Backend.TRITON:
             self.kernels = ai_utils.triton_kernels_dir() / "KernelBench"
+        elif self.backend == ai_hc.Backend.HELION:
+            self.kernels = ai_utils.helion_kernels_dir() / "KernelBench"
         else:
             raise ValueError(f"Unsupported backend: {self.backend}")
 

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -2,6 +2,7 @@ from .equations import eval_ast
 from .equations import eval_eq
 from .finder import ConfigurationError
 from .finder import configure
+from .finder import helion_kernels_dir
 from .finder import kernel_bench_dir
 from .finder import project_root
 from .finder import reset_configuration
@@ -16,6 +17,7 @@ __all__ = [
     "count_torch_flop",
     "eval_ast",
     "eval_eq",
+    "helion_kernels_dir",
     "import_from_path",
     "kernel_bench_dir",
     "project_root",

--- a/ai_bench/utils/finder.py
+++ b/ai_bench/utils/finder.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 _specs_dir: Path | None = None
 _kernels_dir: Path | None = None
 _triton_kernels_dir: Path | None = None
+_helion_kernels_dir: Path | None = None
 _env_loaded: bool = False
 
 
@@ -82,6 +83,7 @@ def configure(
     specs_dir: Path | str | None = None,
     kernels_dir: Path | str | None = None,
     triton_kernels_dir: Path | str | None = None,
+    helion_kernels_dir: Path | str | None = None,
 ) -> None:
     """Configure library paths.
 
@@ -91,6 +93,7 @@ def configure(
         specs_dir: Path to YAML spec files directory
         kernels_dir: Path to PyTorch kernel implementations
         triton_kernels_dir: Path to Triton kernel implementations
+        helion_kernels_dir: Path to Helion kernel implementations
 
     Example:
         >>> import ai_bench
@@ -99,7 +102,7 @@ def configure(
         ...     kernels_dir="/path/to/kernels",
         ... )
     """
-    global _specs_dir, _kernels_dir, _triton_kernels_dir
+    global _specs_dir, _kernels_dir, _triton_kernels_dir, _helion_kernels_dir
 
     if specs_dir is not None:
         _specs_dir = Path(specs_dir)
@@ -107,6 +110,8 @@ def configure(
         _kernels_dir = Path(kernels_dir)
     if triton_kernels_dir is not None:
         _triton_kernels_dir = Path(triton_kernels_dir)
+    if helion_kernels_dir is not None:
+        _helion_kernels_dir = Path(helion_kernels_dir)
 
 
 def reset_configuration() -> None:
@@ -114,10 +119,16 @@ def reset_configuration() -> None:
 
     Useful for testing or reconfiguring.
     """
-    global _specs_dir, _kernels_dir, _triton_kernels_dir, _env_loaded
+    global \
+        _specs_dir, \
+        _kernels_dir, \
+        _triton_kernels_dir, \
+        _helion_kernels_dir, \
+        _env_loaded
     _specs_dir = None
     _kernels_dir = None
     _triton_kernels_dir = None
+    _helion_kernels_dir = None
     _env_loaded = False
 
 
@@ -255,4 +266,33 @@ def triton_kernels_dir() -> Path:
         "AIBENCH_TRITON_KERNELS_DIR",
         default,
         "Triton kernels directory",
+    )
+
+
+def helion_kernels_dir() -> Path:
+    """Path to the Helion kernels directory.
+
+    Can be configured via:
+    - ai_bench.configure(helion_kernels_dir=...)
+    - AIBENCH_HELION_KERNELS_DIR environment variable
+    - Auto-detected from project structure
+
+    Returns:
+        Path to Helion kernels directory
+
+    Raises:
+        ConfigurationError: If path cannot be determined
+    """
+
+    def default() -> Path:
+        path = project_root() / "backends" / "helion"
+        if not path.exists():
+            raise FileNotFoundError(f"Default Helion kernels path not found: {path}")
+        return path
+
+    return _get_path(
+        _helion_kernels_dir,
+        "AIBENCH_HELION_KERNELS_DIR",
+        default,
+        "Helion kernels directory",
     )

--- a/backends/helion/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/helion/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -1,0 +1,100 @@
+# ruff: noqa: E731
+
+import helion
+import helion.language as hl
+import torch
+import torch.nn as nn
+
+
+@helion.kernel(
+    static_shapes=True,
+    configs=[
+        helion.Config(
+            block_sizes=[64, 128, 16],
+            indexing="tensor_descriptor",
+            l2_groupings=[32],
+            loop_orders=[[1, 0]],
+            num_stages=2,
+            num_warps=8,
+            pid_type="flat",
+            range_flattens=[None, None],
+            range_multi_buffers=[None, None],
+            range_num_stages=[0, 2],
+            range_unroll_factors=[0, 1],
+        ),
+        helion.Config(
+            block_sizes=[256, 256, 32],
+            indexing="tensor_descriptor",
+            l2_groupings=[4],
+            loop_orders=[[0, 1]],
+            num_stages=2,
+            num_warps=32,
+            pid_type="flat",
+            range_flattens=[None, False],
+            range_multi_buffers=[None, False],
+            range_num_stages=[0, 2],
+            range_unroll_factors=[0, 1],
+        ),
+        helion.Config(
+            block_sizes=[256, 128, 32],
+            indexing="tensor_descriptor",
+            l2_groupings=[32],
+            loop_orders=[[0, 1]],
+            num_stages=4,
+            num_warps=32,
+            pid_type="persistent_interleaved",
+            range_flattens=[None, False],
+            range_multi_buffers=[True, False],
+            range_num_stages=[1, 4],
+            range_unroll_factors=[4, 1],
+        ),
+        helion.Config(
+            block_sizes=[128, 256, 16],
+            indexing="tensor_descriptor",
+            l2_groupings=[4],
+            loop_orders=[[0, 1]],
+            num_stages=5,
+            num_warps=32,
+            pid_type="persistent_interleaved",
+            range_flattens=[None, True],
+            range_multi_buffers=[False, False],
+            range_num_stages=[1, 4],
+            range_unroll_factors=[2, 0],
+        ),
+    ],
+)
+def _square_matmul_kernel(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+    """
+    Performs square matrix multiplication using Helion.
+    C = A * B
+
+    Args:
+        A: Input matrix A of shape (N, N)
+        B: Input matrix B of shape (N, N)
+
+    Returns:
+        Output matrix C of shape (N, N)
+    """
+    N, N2 = A.size()
+    N3, N4 = B.size()
+    assert N == N2 == N3 == N4, f"size mismatch: A{A.size()}, B{B.size()}"
+
+    out = torch.empty(
+        [N, N], dtype=torch.promote_types(A.dtype, B.dtype), device=A.device
+    )
+
+    for tile_m, tile_n in hl.tile([N, N]):
+        acc = hl.zeros([tile_m, tile_n], dtype=torch.float32)
+        for tile_k in hl.tile(N):
+            acc = torch.addmm(acc, A[tile_m, tile_k], B[tile_k, tile_n])
+        out[tile_m, tile_n] = acc
+
+    return out
+
+
+class Model(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(Model, self).__init__()
+
+    def forward(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+        return _square_matmul_kernel(A, B)

--- a/backends/helion/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/helion/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -1,5 +1,3 @@
-# ruff: noqa: E731
-
 import helion
 import helion.language as hl
 import torch

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -10,9 +10,10 @@ SCRIPTS_DIR=$(realpath $(dirname $0))
 BENCH_BACKEND_TORCH="torch"
 BENCH_BACKEND_TORCH_COMPILE="torch-compile"
 BENCH_BACKEND_TRITON="triton"
+BENCH_BACKEND_HELION="helion"
 
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_HELION})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
   exit 1
@@ -25,7 +26,8 @@ while getopts "b:" arg; do
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
          [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ] || \
-         [ "${OPTARG}" == "${BENCH_BACKEND_TRITON}" ]; then
+         [ "${OPTARG}" == "${BENCH_BACKEND_TRITON}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_HELION}" ]; then
         BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
@@ -58,11 +60,18 @@ echo ""
 echo "--- Run KernelBench (${BENCH_BACKEND})"
 
 BENCH_FLAGS="--xpu --bench"
+
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"
 fi
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TRITON}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --triton"
+fi
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_HELION}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --helion"
+  # Suppress logging to minimize noise in the benchmark output.
+  export HELION_AUTOTUNE_PROGRESS_BAR=0
+  export HELION_AUTOTUNE_LOG_LEVEL=0
 fi
 
 ${AI_BENCH_UV} run python ${SCRIPTS_DIR}/run_kernel_bench.py ${BENCH_FLAGS}

--- a/infra/scripts/run_kernel_bench.py
+++ b/infra/scripts/run_kernel_bench.py
@@ -16,6 +16,8 @@ def main(args):
     # Determine backend.
     if args.triton:
         backend = core.Backend.TRITON
+    elif args.helion:
+        backend = core.Backend.HELION
     else:
         if args.torch_compile:
             backend = core.Backend.PYTORCH_COMPILE
@@ -76,6 +78,12 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Use PyTorch compile mode",
+    )
+    backend_group.add_argument(
+        "--helion",
+        action="store_true",
+        default=False,
+        help="Use Helion backend",
     )
 
     # Run mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: System :: Benchmark",
 ]
-keywords = ["benchmark", "pytorch", "triton", "gpu", "xpu", "kernel", "performance"]
+keywords = [
+  "benchmark", "pytorch", "triton", "helion",
+  "gpu", "xpu", "kernel", "performance"
+]
 dependencies = [
   "PyYAML",
   "numpy",
@@ -45,6 +48,7 @@ cpu = [
 xpu = [
   "torch==2.9.1+xpu",
   "pytorch-triton-xpu",
+  "helion==0.2.9",
 ]
 
 [dependency-groups]
@@ -139,7 +143,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-local-folder = ["ai_bench"]
-known-third-party = ["torch"]
+known-third-party = ["torch", "triton", "helion"]
 known-first-party = ["mlir"]
 force-single-line = true  # Improves merge conflicts
 force-sort-within-sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,10 @@ ignore_missing_imports = true
 module = "triton.*"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "helion.*"
+ignore_missing_imports = true
+
 [tool.ruff]
 src = ["AI-bench"]
 target-version = "py310"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,20 +20,23 @@ class TestBackendEnum:
         assert ai_hc.Backend.PYTORCH == "pytorch"
         assert ai_hc.Backend.PYTORCH_COMPILE == "pytorch-compile"
         assert ai_hc.Backend.TRITON == "triton"
+        assert ai_hc.Backend.HELION == "helion"
 
     def test_backend_iteration(self):
         """Test that all backends can be iterated."""
         backends = list(ai_hc.Backend)
-        assert len(backends) == 3
+        assert len(backends) == 4
         assert ai_hc.Backend.PYTORCH in backends
         assert ai_hc.Backend.PYTORCH_COMPILE in backends
         assert ai_hc.Backend.TRITON in backends
+        assert ai_hc.Backend.HELION in backends
 
     def test_backend_from_string(self):
         """Test creating backend from string."""
         assert ai_hc.Backend("pytorch") == ai_hc.Backend.PYTORCH
         assert ai_hc.Backend("pytorch-compile") == ai_hc.Backend.PYTORCH_COMPILE
         assert ai_hc.Backend("triton") == ai_hc.Backend.TRITON
+        assert ai_hc.Backend("helion") == ai_hc.Backend.HELION
 
     def test_backend_invalid_string(self):
         """Test that invalid string raises error."""
@@ -204,6 +207,20 @@ class TestKernelBenchRunnerInit:
         assert "triton" in str(kb_runner.kernels)
 
     @mock.patch("os.path.isdir")
+    def test_init_helion_backend(self, mock_isdir):
+        """Test runner initialization with Helion backend."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            spec_type=ai_hc.SpecKey.V_CI,
+            device=torch.device("cpu"),
+            backend=ai_hc.Backend.HELION,
+        )
+
+        assert kb_runner.backend == ai_hc.Backend.HELION
+        assert "helion" in str(kb_runner.kernels)
+
+    @mock.patch("os.path.isdir")
     def test_init_missing_kernels_dir(self, mock_isdir):
         """Test runner raises error when kernels directory is missing."""
         mock_isdir.return_value = False
@@ -257,16 +274,21 @@ class TestKernelBenchRunnerExecution:
             triton_kernels_dir = (
                 tmpdir / "backends" / "triton" / "KernelBench" / "level1"
             )
+            helion_kernels_dir = (
+                tmpdir / "backends" / "helion" / "KernelBench" / "level1"
+            )
 
             specs_dir.mkdir(parents=True)
             pytorch_kernels_dir.mkdir(parents=True)
             triton_kernels_dir.mkdir(parents=True)
+            helion_kernels_dir.mkdir(parents=True)
 
             yield {
                 "root": tmpdir,
                 "specs": specs_dir,
                 "pytorch_kernels": pytorch_kernels_dir,
                 "triton_kernels": triton_kernels_dir,
+                "helion_kernels": helion_kernels_dir,
             }
 
     def _create_spec_file(self, specs_dir: Path, filename: str, content: str):
@@ -417,12 +439,27 @@ class Model(torch.nn.Module):
         # Simulated Triton kernel (same result for testing).
         return x @ x
 """
+        helion_kernel = """
+import torch
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backend = "helion"
+
+    def forward(self, x):
+        # Simulated Helion kernel (same result for testing).
+        return x @ x
+"""
         self._create_spec_file(temp_dirs["specs"], "matmul.yaml", spec_content)
         self._create_kernel_file(
             temp_dirs["pytorch_kernels"], "matmul.py", pytorch_kernel
         )
         self._create_kernel_file(
             temp_dirs["triton_kernels"], "matmul.py", triton_kernel
+        )
+        self._create_kernel_file(
+            temp_dirs["helion_kernels"], "matmul.py", helion_kernel
         )
 
         with mock.patch(
@@ -452,10 +489,19 @@ class Model(torch.nn.Module):
             )
             assert triton_runner.backend == ai_hc.Backend.TRITON
 
+            # Run with Helion backend.
+            helion_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.HELION,
+            )
+            assert helion_runner.backend == ai_hc.Backend.HELION
+
             # Verify they use different kernel directories.
             assert "KernelBench" in str(pytorch_runner.kernels)
             assert "triton" not in str(pytorch_runner.kernels)
             assert "triton" in str(triton_runner.kernels)
+            assert "helion" in str(helion_runner.kernels)
 
     def test_run_kernels_with_inits(self, temp_dirs):
         """Test running kernel that requires initialization parameters."""
@@ -616,10 +662,12 @@ class TestIntegration:
                 tmpdir / "third_party" / "KernelBench" / "KernelBench" / "level1"
             )
             triton_dir = tmpdir / "backends" / "triton" / "KernelBench" / "level1"
+            helion_dir = tmpdir / "backends" / "helion" / "KernelBench" / "level1"
 
             specs_dir.mkdir(parents=True)
             pytorch_dir.mkdir(parents=True)
             triton_dir.mkdir(parents=True)
+            helion_dir.mkdir(parents=True)
 
             # Create spec.
             spec = """
@@ -675,6 +723,21 @@ class Model(torch.nn.Module):
 '''
             (triton_dir / "matmul.py").write_text(triton_kernel)
 
+            # Create Helion kernel (mocked - same behavior).
+            helion_kernel = '''
+import torch
+
+class Model(torch.nn.Module):
+    """Mocked Helion kernel with same interface."""
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, A, B):
+        # In real usage, this would be a Helion kernel.
+        return torch.matmul(A, B)
+'''
+            (helion_dir / "matmul.py").write_text(helion_kernel)
+
             yield tmpdir
 
     def test_full_ci_pipeline_pytorch(self, integration_setup):
@@ -713,6 +776,18 @@ class Model(torch.nn.Module):
             )
             kb_runner.run_kernels()
 
+    def test_full_ci_pipeline_helion(self, integration_setup):
+        """Test complete CI pipeline with Helion backend."""
+        with mock.patch(
+            "ai_bench.utils.finder.project_root", return_value=integration_setup
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.HELION,
+            )
+            kb_runner.run_kernels()
+
     def test_full_bench_pipeline(self, integration_setup):
         """Test complete benchmark pipeline."""
         with mock.patch(
@@ -741,6 +816,11 @@ class Model(torch.nn.Module):
                 device=torch.device("cpu"),
                 backend=ai_hc.Backend.TRITON,
             )
+            helion_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.HELION,
+            )
 
             pytorch_model_cls = pytorch_runner.load_model(
                 integration_setup
@@ -758,9 +838,18 @@ class Model(torch.nn.Module):
                 / "level1"
                 / "matmul.py"
             )
+            helion_model_cls = helion_runner.load_model(
+                integration_setup
+                / "backends"
+                / "helion"
+                / "KernelBench"
+                / "level1"
+                / "matmul.py"
+            )
 
             pytorch_model = pytorch_model_cls()
             triton_model = triton_model_cls()
+            helion_model = helion_model_cls()
 
             # Create deterministic inputs.
             torch.manual_seed(42)
@@ -769,8 +858,10 @@ class Model(torch.nn.Module):
 
             pytorch_result = pytorch_model(A, B)
             triton_result = triton_model(A, B)
+            helion_result = helion_model(A, B)
 
             assert torch.allclose(pytorch_result, triton_result)
+            assert torch.allclose(pytorch_result, helion_result)
 
 
 if __name__ == "__main__":

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -46,6 +46,15 @@ class TestConfiguration:
 
         assert finder.triton_kernels_dir() == triton_dir
 
+    def test_configure_helion_kernels_dir(self, tmp_path):
+        """Test configuring Helion kernels directory."""
+        helion_dir = tmp_path / "helion"
+        helion_dir.mkdir()
+
+        finder.configure(helion_kernels_dir=helion_dir)
+
+        assert finder.helion_kernels_dir() == helion_dir
+
     def test_configure_with_string_path(self, tmp_path):
         """Test configuring with string path instead of Path object."""
         specs_dir = tmp_path / "specs"
@@ -109,6 +118,7 @@ class TestEnvironmentVariables:
             "AIBENCH_SPECS_DIR",
             "AIBENCH_KERNELS_DIR",
             "AIBENCH_TRITON_KERNELS_DIR",
+            "AIBENCH_HELION_KERNELS_DIR",
         ]:
             self._saved_env[key] = os.environ.get(key)
 
@@ -147,6 +157,15 @@ class TestEnvironmentVariables:
         os.environ["AIBENCH_TRITON_KERNELS_DIR"] = str(triton_dir)
 
         assert finder.triton_kernels_dir() == triton_dir
+
+    def test_helion_kernels_from_env_var(self, tmp_path):
+        """Test Helion kernels path from environment variable."""
+        helion_dir = tmp_path / "helion"
+        helion_dir.mkdir()
+
+        os.environ["AIBENCH_HELION_KERNELS_DIR"] = str(helion_dir)
+
+        assert finder.helion_kernels_dir() == helion_dir
 
     def test_env_var_nonexistent_path_raises(self, tmp_path):
         """Test that env var with nonexistent path raises error."""


### PR DESCRIPTION
Adds support for running KernelBench problems with Helion backend.

The new backend is registered and available through runner scripts and in benchmarking CI job.