### PR TITLE
[problems] KernelBench level1 models

### DIFF
--- a/problems/specs/KernelBench/level1/21_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level1/21_Sigmoid.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/22_Tanh.yaml
+++ b/problems/specs/KernelBench/level1/22_Tanh.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/23_Softmax.yaml
+++ b/problems/specs/KernelBench/level1/23_Softmax.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
+++ b/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/25_Swish.yaml
+++ b/problems/specs/KernelBench/level1/25_Swish.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/26_GELU_.yaml
+++ b/problems/specs/KernelBench/level1/26_GELU_.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/27_SELU_.yaml
+++ b/problems/specs/KernelBench/level1/27_SELU_.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
+++ b/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/29_Softplus.yaml
+++ b/problems/specs/KernelBench/level1/29_Softplus.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/30_Softsign.yaml
+++ b/problems/specs/KernelBench/level1/30_Softsign.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/31_ELU.yaml
+++ b/problems/specs/KernelBench/level1/31_ELU.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits:
+  - dim: ALPHA
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512
+      ALPHA: 1.0

--- a/problems/specs/KernelBench/level1/32_HardTanh.yaml
+++ b/problems/specs/KernelBench/level1/32_HardTanh.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/33_BatchNorm.py.yaml
+++ b/problems/specs/KernelBench/level1/33_BatchNorm.py.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64

--- a/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
+++ b/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: FEATURES
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64

--- a/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
+++ b/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
@@ -1,0 +1,18 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: FEATURES
+  - dim: NUM_GROUPS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 8
+      NUM_GROUPS: 4
+      DIM1: 32
+      DIM2: 32

--- a/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
+++ b/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: FEATURES
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64

--- a/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
+++ b/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64

--- a/problems/specs/KernelBench/level1/38_L1Norm_.yaml
+++ b/problems/specs/KernelBench/level1/38_L1Norm_.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/39_L2Norm_.yaml
+++ b/problems/specs/KernelBench/level1/39_L2Norm_.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 128
+      DIM: 512

--- a/problems/specs/KernelBench/level1/40_LayerNorm.yaml
+++ b/problems/specs/KernelBench/level1/40_LayerNorm.yaml
@@ -1,0 +1,17 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: NORMALIZED_SHAPE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64
+      NORMALIZED_SHAPE: [4, 64, 64] # TODO: bind these to other dims

--- a/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
@@ -1,0 +1,24 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, SEQUENCE_LENGTH]
+    dtype: float16
+
+inits:
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+  - dim: RETURN_INDICES
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 24
+      SEQUENCE_LENGTH: 64
+      KERNEL_SIZE: 2
+      STRIDE: 1
+      PADDING: 1
+      DILATION: 3
+      RETURN_INDICES: false

--- a/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
@@ -1,0 +1,23 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      CHANNELS: 8
+      HEIGHT: 32
+      WIDTH: 32
+      KERNEL_SIZE: 2
+      STRIDE: 1
+      PADDING: 1
+      DILATION: 1

--- a/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
+++ b/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: FEATURES
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      FEATURES: 4
+      DIM1: 64
+      DIM2: 64

--- a/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, INPUT_LENGTH]
+    dtype: float16
+
+inits:
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 32
+      INPUT_LENGTH: 128
+      KERNEL_SIZE: 2
+      STRIDE: 1
+      PADDING: 1

--- a/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
@@ -1,0 +1,17 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      CHANNELS: 16
+      HEIGHT: 128
+      WIDTH: 128
+      KERNEL_SIZE: 3

--- a/problems/specs/KernelBench/level1/46_Average_Pooling_3D.yaml
+++ b/problems/specs/KernelBench/level1/46_Average_Pooling_3D.yaml
@@ -1,0 +1,22 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float32
+
+inits:
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+
+ci:
+  - params: [x]
+    dtype: float32 # "avg_pool3d_out_frame" not implemented for 'Half'
+    dims:
+      BATCH_SIZE: 2
+      CHANNELS: 8
+      DEPTH: 16
+      HEIGHT: 16
+      WIDTH: 32
+      KERNEL_SIZE: 3
+      STRIDE: 2
+      PADDING: 1

--- a/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: REDUCE_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      REDUCE_DIM: 1

--- a/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: REDUCE_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      REDUCE_DIM: 1

--- a/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: REDUCE_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      REDUCE_DIM: 1

--- a/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
@@ -1,0 +1,17 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      NUM_CLASSES: 10
+      IN_CHANNELS: 3
+      HEIGHT: 64
+      WIDTH: 64

--- a/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: ARGMAX_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      ARGMAX_DIM: 1

--- a/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: ARGMIN_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      ARGMIN_DIM: 1

--- a/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
@@ -1,0 +1,16 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM1, DIM2]
+    dtype: float16
+
+inits:
+  - dim: REDUCE_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      DIM1: 64
+      DIM2: 63
+      REDUCE_DIM: 1

--- a/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, WIDTH, HEIGHT]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 3
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      DEPTH: 16
+      WIDTH: 16
+      HEIGHT: 16

--- a/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      HEIGHT: 32
+      WIDTH: 64

--- a/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: [5, 7]
+      HEIGHT: 64
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 16
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      HEIGHT: 64
+      WIDTH: 64

--- a/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH_IN, HEIGHT_IN, WIDTH_IN]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 5, 7]
+      DEPTH_IN: 4
+      HEIGHT_IN: 32
+      WIDTH_IN: 64

--- a/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH, DEPTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 3
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      HEIGHT: 32
+      WIDTH: 32
+      DEPTH: 5

--- a/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, WIDTH, HEIGHT, DEPTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 3
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 5, 7]
+      WIDTH: 16
+      HEIGHT: 16
+      DEPTH: 16

--- a/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 24
+      OUT_CHANNELS: 24
+      KERNEL_SIZE: 3
+      DEPTH: 16
+      HEIGHT: 16
+      WIDTH: 16

--- a/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [5, 9]
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
+++ b/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
@@ -1,0 +1,19 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      LENGTH: 128

--- a/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 7]
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 3
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 5, 7]
+      DEPTH: 4
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
+++ b/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
@@ -1,0 +1,19 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 16
+      KERNEL_SIZE: 3
+      LENGTH: 128

--- a/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, WIDTH, HEIGHT]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 2
+      OUT_CHANNELS: 4
+      KERNEL_SIZE: [3, 5, 5]
+      DEPTH: 32
+      WIDTH: 32
+      HEIGHT: 32

--- a/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 5]
+      HEIGHT_IN: 16
+      WIDTH_IN: 32

--- a/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
@@ -1,0 +1,21 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 12
+      OUT_CHANNELS: 6
+      KERNEL_SIZE: 3
+      DEPTH: 24
+      HEIGHT: 24
+      WIDTH: 24

--- a/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
@@ -1,0 +1,20 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      HEIGHT_IN: 16
+      WIDTH_IN: 32

--- a/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
+++ b/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
@@ -1,0 +1,29 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: OUTPUT_PADDING
+  - dim: GROUPS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 4
+      KERNEL_SIZE: [3, 5, 7]
+      STRIDE: [2, 2, 2]
+      PADDING: [1, 2, 3]
+      OUTPUT_PADDING: [1, 1, 1]
+      GROUPS: 2
+      DEPTH: 12
+      HEIGHT: 24
+      WIDTH: 48

--- a/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
+++ b/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
@@ -1,0 +1,27 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: GROUPS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 4
+      KERNEL_SIZE: 3
+      STRIDE: 2
+      PADDING: 1
+      GROUPS: 4
+      DEPTH: 8
+      HEIGHT: 16
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
+++ b/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
@@ -1,0 +1,25 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 5
+      STRIDE: 1
+      PADDING: 0
+      DILATION: 3
+      LENGTH: 128

--- a/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
@@ -1,0 +1,28 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+  - dim: GROUPS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 5]
+      STRIDE: [2, 3]
+      PADDING: [1, 2]
+      DILATION: [2, 1]
+      GROUPS: 2
+      HEIGHT: 16
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
+++ b/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
@@ -1,0 +1,23 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 3
+      DILATION: 4
+      LENGTH: 128

--- a/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
+++ b/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
@@ -1,0 +1,27 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 2
+      PADDING: 1
+      DILATION: 2
+      DEPTH: 8
+      HEIGHT: 16
+      WIDTH: 16

--- a/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
+++ b/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
@@ -1,0 +1,24 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: [3, 7]
+      STRIDE: [1, 1]
+      PADDING: [1, 3]
+      HEIGHT: 16
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
@@ -1,0 +1,25 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 2
+      PADDING: 1
+      DILATION: 2
+      LENGTH: 128

--- a/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
+++ b/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
@@ -1,0 +1,26 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 32
+      KERNEL_SIZE: [5, 9]
+      STRIDE: 1
+      PADDING: [2, 4]
+      DILATION: [2, 3]
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
+++ b/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
@@ -1,0 +1,26 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 5
+      PADDING: 1
+      DILATION: 2
+      HEIGHT_IN: 16
+      WIDTH_IN: 32

--- a/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
@@ -1,0 +1,22 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 16
+      KERNEL_SIZE: 3
+      STRIDE: 1
+      PADDING: 0
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
@@ -1,0 +1,24 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 1
+      PADDING: 0
+      DILATION: 1
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
@@ -1,0 +1,24 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 1
+      PADDING: 0
+      HEIGHT_IN: 16
+      WIDTH_IN: 32

--- a/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
@@ -1,0 +1,36 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE_H
+  - dim: KERNEL_SIZE_W
+  - dim: STRIDE_H
+  - dim: STRIDE_W
+  - dim: PADDING_H
+  - dim: PADDING_W
+  - dim: DILATION_H
+  - dim: DILATION_W
+  - dim: GROUPS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 4
+      KERNEL_SIZE_H: 3
+      KERNEL_SIZE_W: 7
+      STRIDE_H: 1
+      STRIDE_W: 1
+      PADDING_H: 0
+      PADDING_W: 0
+      DILATION_H: 1
+      DILATION_W: 1
+      GROUPS: 16
+      HEIGHT: 16
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
+++ b/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
@@ -1,0 +1,26 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: PADDING
+  - dim: DILATION
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      KERNEL_SIZE: 3
+      STRIDE: 1
+      PADDING: 1
+      DILATION: 1
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
+++ b/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
@@ -1,0 +1,18 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      IN_CHANNELS: 4
+      OUT_CHANNELS: 8
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
+++ b/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
@@ -1,0 +1,13 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 32
+      DIM: 32

--- a/problems/specs/KernelBench/level1/89_cumsum.yaml
+++ b/problems/specs/KernelBench/level1/89_cumsum.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits:
+  - dim: SCAN_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64
+      SCAN_DIM: 1

--- a/problems/specs/KernelBench/level1/90_cumprod.yaml
+++ b/problems/specs/KernelBench/level1/90_cumprod.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits:
+  - dim: SCAN_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64
+      SCAN_DIM: 1

--- a/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
+++ b/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits:
+  - dim: SCAN_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64
+      SCAN_DIM: 1

--- a/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
+++ b/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
@@ -1,0 +1,15 @@
+inputs:
+  x:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits:
+  - dim: SCAN_DIM
+
+ci:
+  - params: [x]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64
+      SCAN_DIM: 1

--- a/problems/specs/KernelBench/level1/96_HuberLoss.yaml
+++ b/problems/specs/KernelBench/level1/96_HuberLoss.yaml
@@ -1,0 +1,16 @@
+inputs:
+  predictions:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+  targets:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [predictions, targets]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
+++ b/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
@@ -1,0 +1,21 @@
+inputs:
+  Q:
+    shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
+    dtype: float16
+  K:
+    shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
+    dtype: float16
+  V:
+    shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [Q, K, V]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      NUM_HEADS: 8
+      SEQUENCE_LENGTH: 16
+      EMBEDDING_DIMENSION: 32


### PR DESCRIPTION
Adds majority of level1 specs in CI variant.

The missing level1 specs were skipped due to need for complex input initialization which is currently unsupported.