### PR TITLE
[problems] Make CI variants smaller

### DIFF
--- a/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
@@ -13,9 +13,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
       MUL: 2.0
       NEG_SLOPE: 0.1
     flop: "2*BATCH*IN_FEAT*OUT_FEAT + 4*BATCH*OUT_FEAT"

--- a/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
@@ -12,9 +12,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_SIZE: 128
-      HIDDEN_SIZE: 128
+      BATCH: 2
+      IN_SIZE: 64
+      HIDDEN_SIZE: 64
       SCALE: 1.5
     flop: "2*BATCH*IN_SIZE*HIDDEN_SIZE + BATCH*HIDDEN_SIZE"
 

--- a/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
@@ -13,13 +13,13 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 16
-      IN_CHANNELS: 32
-      OUT_CHANNELS: 64
-      HEIGHT: 64
-      WIDTH: 64
+      BATCH: 2
+      IN_CHANNELS: 16
+      OUT_CHANNELS: 32
+      HEIGHT: 32
+      WIDTH: 32
       KERNEL_SIZE: 3
-      BIAS_SHAPE: [64, 1, 1]
+      BIAS_SHAPE: [32, 1, 1]
     flop: "2*BATCH*OUT_CHANNELS*HEIGHT*WIDTH*IN_CHANNELS*KERNEL_SIZE*KERNEL_SIZE + BATCH*OUT_CHANNELS*HEIGHT*WIDTH"
 
 bench-gpu:

--- a/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
@@ -11,9 +11,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
     flop: "2*BATCH*IN_FEAT*OUT_FEAT"
 
 bench-gpu:

--- a/problems/specs/KernelBench/level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.yaml
@@ -17,14 +17,14 @@ ci:
   - params: [X]
     dtype: float32
     dims:
-      BATCH: 4
+      BATCH: 2
       IN_CH: 8
-      OUT_CH: 64
-      H: 32
-      W: 32
+      OUT_CH: 32
+      H: 16
+      W: 16
       KERNEL_SIZE: 3
-      NUM_GROUPS: 16
-      SCALE_SHAPE: [64, 1, 1]
+      NUM_GROUPS: 8
+      SCALE_SHAPE: [32, 1, 1]
       MAXPOOL_KERNEL_SIZE: 4
       CLAMP_MIN: 0.0
       CLAMP_MAX: 1.0

--- a/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
+++ b/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
@@ -15,10 +15,10 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
-      ADD_VALUE_SHAPE: [128]
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
+      ADD_VALUE_SHAPE: [64]
     flop: "2*BATCH*IN_FEAT*OUT_FEAT"
 
 bench-gpu:

--- a/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
+++ b/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
@@ -15,9 +15,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
       BN_EPS: 0.00001
       BN_MOMENTUM: 0.1
       BIAS_SHAPE: [1]

--- a/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
+++ b/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
@@ -13,10 +13,10 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
-      POOL_KERNEL_SIZE: 16
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
+      POOL_KERNEL_SIZE: 8
       SCALE: 2.0
     flop: "BATCH*IN_FEAT*(POOL_KERNEL_SIZE-1) + 2*BATCH*OUT_FEAT*IN_FEAT + BATCH*OUT_FEAT"
 

--- a/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
@@ -11,9 +11,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
     flop: "2*BATCH*IN_FEAT*OUT_FEAT"
 
 bench-gpu:

--- a/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
@@ -13,9 +13,9 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_FEAT: 128
-      OUT_FEAT: 128
+      BATCH: 2
+      IN_FEAT: 64
+      OUT_FEAT: 64
       SUB_VAL: 2.0
       MUL_VAL: 1.5
     flop: "2*BATCH*IN_FEAT*OUT_FEAT + 2*BATCH*OUT_FEAT"

--- a/problems/specs/KernelBench/level3/1_MLP.yaml
+++ b/problems/specs/KernelBench/level3/1_MLP.yaml
@@ -12,10 +12,10 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_SIZE: 128
-      LAYER_SIZES: [128, 128]
-      OUT_SIZE: 64
+      BATCH: 4
+      IN_SIZE: 32
+      LAYER_SIZES: [32, 32]
+      OUT_SIZE: 16
 
 bench-gpu:
   - params: [X]

--- a/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
+++ b/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
@@ -12,10 +12,10 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_SIZE: 64
-      LAYER_SIZES: [128, 128]
-      OUT_SIZE: 64
+      BATCH: 4
+      IN_SIZE: 32
+      LAYER_SIZES: [32, 32]
+      OUT_SIZE: 16
 
 bench-gpu:
   - params: [X]

--- a/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
+++ b/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
@@ -12,15 +12,15 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
-      IN_SIZE: 128
+      BATCH: 8
+      IN_SIZE: 64
       LAYER_SIZES: [
-        32, 32, 32, 32,
-        32, 32, 32, 32,
-        32, 32, 32, 32,
-        32, 32, 32, 32
+        8, 8, 8, 8,
+        8, 8, 8, 8,
+        8, 8, 8, 8,
+        8, 8, 8, 8
       ]
-      OUT_SIZE: 128
+      OUT_SIZE: 64
 
 bench-gpu:
   - params: [X]

--- a/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
+++ b/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
@@ -14,10 +14,10 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 8
-      MAX_SEQLEN: 256
-      SEQ_LEN: 128
-      N_EMBD: 96
+      BATCH: 2
+      MAX_SEQLEN: 128
+      SEQ_LEN: 64
+      N_EMBD: 48
       N_HEAD: 2
       ATTN_PDROP: 0.0
       RESID_PDROP: 0.0

--- a/problems/specs/KernelBench/level3/4_LeNet5.yaml
+++ b/problems/specs/KernelBench/level3/4_LeNet5.yaml
@@ -10,7 +10,7 @@ ci:
   - params: [X]
     dtype: float16
     dims:
-      BATCH: 32
+      BATCH: 2
       IN_1: 1
       IN_2: 32
       IN_3: 32

--- a/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
+++ b/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
@@ -24,8 +24,8 @@ ci:
       OUT_5x5: 24
       POOL_PROJ: 32
       BATCH: 1
-      HEIGHT: 112
-      WIDTH: 112
+      HEIGHT: 56
+      WIDTH: 56
 
 # Disabled due to the error:
 # Condition append_res Failed on void ZeCollector::PostAppendKernelCommandCommon

--- a/problems/specs/KernelBench/level3/9_ResNet18.yaml
+++ b/problems/specs/KernelBench/level3/9_ResNet18.yaml
@@ -14,8 +14,8 @@ ci:
       NUM_CLASSES: 4
       IN_1: 2
       IN_2: 3
-      IN_3: 112
-      IN_4: 112
+      IN_3: 56
+      IN_4: 56
 
 bench-gpu:
   - params: [X]


### PR DESCRIPTION
Decreases CI variants' shapes to speed up execution.
Mostly beneficial when testing locally.