### PR TITLE
[problems] KernelBench level3 models

### DIFF
--- a/problems/specs/KernelBench/level3/10_ResNet101.yaml
+++ b/problems/specs/KernelBench/level3/10_ResNet101.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: LAYERS
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      LAYERS: [3, 2, 11, 3]
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/11_VGG16.yaml
+++ b/problems/specs/KernelBench/level3/11_VGG16.yaml
@@ -1,0 +1,18 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+# TODO: Reenable for CI
+SKIP: # Compute too long for local use
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 224
+      WIDTH: 224
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/12_VGG19.yaml
+++ b/problems/specs/KernelBench/level3/12_VGG19.yaml
@@ -1,0 +1,18 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+# TODO: Reenable for CI
+SKIP: # Compute too long for local use
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 224
+      WIDTH: 224
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
+++ b/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
@@ -1,0 +1,18 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, NUM_INPUT_FEATURES, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_INPUT_FEATURES
+  - dim: NUM_OUTPUT_FEATURES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      NUM_INPUT_FEATURES: 4
+      NUM_OUTPUT_FEATURES: 8
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
+++ b/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, NUM_INPUT_FEATURES, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_LAYERS
+  - dim: NUM_INPUT_FEATURES
+  - dim: GROWTH_RATE
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      NUM_INPUT_FEATURES: 2
+      NUM_LAYERS: 3
+      GROWTH_RATE: 4
+      HEIGHT: 32
+      WIDTH: 32

--- a/problems/specs/KernelBench/level3/15_DenseNet121.yaml
+++ b/problems/specs/KernelBench/level3/15_DenseNet121.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: GROWTH_RATE
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 112
+      WIDTH: 112
+      GROWTH_RATE: 4
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/16_DenseNet201.yaml
+++ b/problems/specs/KernelBench/level3/16_DenseNet201.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: GROWTH_RATE
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 112
+      WIDTH: 112
+      GROWTH_RATE: 4
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
+++ b/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: SQUEEZE_CHANNELS
+  - dim: EXPAND1X1_CHANNELS
+  - dim: EXPAND3X3_CHANNELS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      SQUEEZE_CHANNELS: 2
+      EXPAND1X1_CHANNELS: 8
+      EXPAND3X3_CHANNELS: 8

--- a/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
+++ b/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 32
+      WIDTH: 32
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
+++ b/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+  - dim: INPUT_CHANNELS
+  - dim: ALPHA
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 224
+      WIDTH: 224
+      NUM_CLASSES: 2
+      ALPHA: 1.0

--- a/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
+++ b/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 224
+      WIDTH: 224
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
+++ b/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
@@ -1,0 +1,24 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: KERNEL_SIZE
+  - dim: STRIDE
+  - dim: EXPAND_RATIO
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 7
+      OUT_CHANNELS: 12
+      HEIGHT: 56
+      WIDTH: 56
+      KERNEL_SIZE: 3
+      STRIDE: 2
+      EXPAND_RATIO: 2

--- a/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
+++ b/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
+++ b/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 120
+      WIDTH: 120
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
+++ b/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 2
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
+++ b/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: GROUPS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 30
+      OUT_CHANNELS: 60
+      HEIGHT: 56
+      WIDTH: 56
+      GROUPS: 3

--- a/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
+++ b/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/27_RegNet.yaml
+++ b/problems/specs/KernelBench/level3/27_RegNet.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: INPUT_CHANNELS
+  - dim: STAGES
+  - dim: BLOCK_WIDTHS
+  - dim: OUTPUT_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      STAGES: 3
+      BLOCK_WIDTHS: [8, 16, 32]
+      OUTPUT_CLASSES: 2

--- a/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
@@ -1,0 +1,32 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
+    dtype: float16
+
+inits:
+  - dim: IMAGE_SIZE
+  - dim: PATCH_SIZE
+  - dim: NUM_CLASSES
+  - dim: DIM
+  - dim: DEPTH
+  - dim: HEADS
+  - dim: MLP_DIM
+  - dim: CHANNELS
+  - dim: DROPOUT
+  - dim: EMB_DROPOUT
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      CHANNELS: 3
+      IMAGE_SIZE: 56
+      PATCH_SIZE: 4
+      NUM_CLASSES: 2
+      DIM: 32
+      DEPTH: 3
+      HEADS: 4
+      MLP_DIM: 64
+      DROPOUT: 0.0
+      EMB_DROPOUT: 0.0

--- a/problems/specs/KernelBench/level3/29_SwinMLP.yaml
+++ b/problems/specs/KernelBench/level3/29_SwinMLP.yaml
@@ -1,0 +1,14 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      IMAGE_SIZE: 224

--- a/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
+++ b/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
@@ -1,0 +1,14 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
+    dtype: float16
+
+inits: []
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      IMAGE_SIZE: 224

--- a/problems/specs/KernelBench/level3/31_VisionAttention.yaml
+++ b/problems/specs/KernelBench/level3/31_VisionAttention.yaml
@@ -1,0 +1,18 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, EMBED_DIM, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: EMBED_DIM
+  - dim: NUM_HEADS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      EMBED_DIM: 16
+      HEIGHT: 16
+      WIDTH: 16
+      NUM_HEADS: 2

--- a/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+  - dim: EMBED_DIM
+  - dim: NUM_HEADS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 3
+      IMAGE_SIZE: 32
+      NUM_CLASSES: 2
+      EMBED_DIM: 64
+      NUM_HEADS: 2

--- a/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
+++ b/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
@@ -1,0 +1,21 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  INITIAL_HIDDEN:
+    shape: [BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: OUTPUT_SIZE
+
+ci:
+  - params: [X, INITIAL_HIDDEN]
+    dtype: float32 # TODO: Fix model dtype
+    dims:
+      BATCH_SIZE: 256
+      INPUT_SIZE: 32
+      HIDDEN_SIZE: 32
+      OUTPUT_SIZE: 16

--- a/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
+++ b/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: OUTPUT_SIZE
+
+ci:
+  - params: [X, H0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_SIZE: 64
+      HIDDEN_SIZE: 16
+      OUTPUT_SIZE: 8
+      SEQUENCE_LENGTH: 16

--- a/problems/specs/KernelBench/level3/35_LSTM.yaml
+++ b/problems/specs/KernelBench/level3/35_LSTM.yaml
@@ -1,0 +1,29 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+  C0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+  - dim: OUTPUT_SIZE
+  - dim: DROPOUT
+
+ci:
+  - params: [X, H0, C0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      OUTPUT_SIZE: 10
+      DROPOUT: 0.0

--- a/problems/specs/KernelBench/level3/36_LSTMHn.yaml
+++ b/problems/specs/KernelBench/level3/36_LSTMHn.yaml
@@ -1,0 +1,29 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+  C0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+  - dim: OUTPUT_SIZE
+  - dim: DROPOUT
+
+ci:
+  - params: [X, H0, C0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      OUTPUT_SIZE: 10
+      DROPOUT: 0.0

--- a/problems/specs/KernelBench/level3/37_LSTMCn.yaml
+++ b/problems/specs/KernelBench/level3/37_LSTMCn.yaml
@@ -1,0 +1,29 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+  C0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+  - dim: OUTPUT_SIZE
+  - dim: DROPOUT
+
+ci:
+  - params: [X, H0, C0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      OUTPUT_SIZE: 10
+      DROPOUT: 0.0

--- a/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
@@ -1,0 +1,30 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+  C0:
+    shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+  - dim: OUTPUT_SIZE
+  - dim: DROPOUT
+
+ci:
+  - params: [X, H0, C0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      NUM_LAYERS_BIDIRECTIONAL: 6
+      OUTPUT_SIZE: 10
+      DROPOUT: 0.0

--- a/problems/specs/KernelBench/level3/39_GRU.yaml
+++ b/problems/specs/KernelBench/level3/39_GRU.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+
+ci:
+  - params: [X, H0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3

--- a/problems/specs/KernelBench/level3/40_GRUHidden.yaml
+++ b/problems/specs/KernelBench/level3/40_GRUHidden.yaml
@@ -1,0 +1,22 @@
+inputs:
+  X:
+    shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+
+ci:
+  - params: [X, H0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3

--- a/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
@@ -1,0 +1,23 @@
+inputs:
+  X:
+    shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+
+ci:
+  - params: [X, H0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      NUM_LAYERS_BIDIRECTIONAL: 6

--- a/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
+++ b/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
@@ -1,0 +1,23 @@
+inputs:
+  X:
+    shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
+    dtype: float16
+  H0:
+    shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
+    dtype: float16
+
+inits:
+  - dim: INPUT_SIZE
+  - dim: HIDDEN_SIZE
+  - dim: NUM_LAYERS
+
+ci:
+  - params: [X, H0]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      INPUT_SIZE: 8
+      HIDDEN_SIZE: 16
+      NUM_LAYERS: 3
+      NUM_LAYERS_BIDIRECTIONAL: 6

--- a/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
+++ b/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
@@ -1,0 +1,23 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, N_EMBD]
+    dtype: float16
+
+inits:
+  - dim: N_EMBD
+  - dim: N_HEAD
+  - dim: ATTN_PDROP
+  - dim: RESID_PDROP
+  - dim: MAX_SEQLEN
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      N_EMBD: 48
+      N_HEAD: 2
+      ATTN_PDROP: 0.0
+      RESID_PDROP: 0.0
+      MAX_SEQLEN: 32

--- a/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
+++ b/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: FEATURES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 8
+      OUT_CHANNELS: 4
+      HEIGHT: 32
+      WIDTH: 64
+      FEATURES: 32

--- a/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, NUM_FEATURES, FEATURE_SIZE]
+    dtype: float16
+
+inits:
+  - dim: CLUSTER_SIZE
+  - dim: FEATURE_SIZE
+  - dim: GHOST_CLUSTERS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      NUM_FEATURES: 10
+      FEATURE_SIZE: 32
+      CLUSTER_SIZE: 8
+      GHOST_CLUSTERS: 2

--- a/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, NUM_FEATURES, FEATURE_SIZE]
+    dtype: float16
+
+inits:
+  - dim: CLUSTER_SIZE
+  - dim: FEATURE_SIZE
+  - dim: GHOST_CLUSTERS
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      NUM_FEATURES: 10
+      FEATURE_SIZE: 32
+      CLUSTER_SIZE: 8
+      GHOST_CLUSTERS: 0

--- a/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
+++ b/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
@@ -1,0 +1,23 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQ_LENGTH, N_HEADS, D_HEAD]
+    dtype: float16
+
+inits:
+  - dim: BATCH_SIZE
+  - dim: SEQ_LENGTH
+  - dim: N_HEADS
+  - dim: D_HEAD
+  - dim: D_STATE
+  - dim: BLOCK_LEN
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQ_LENGTH: 32
+      N_HEADS: 2
+      D_HEAD: 32
+      D_STATE: 8
+      BLOCK_LEN: 32

--- a/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
+++ b/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
@@ -1,0 +1,23 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQ_LENGTH, N_HEADS, D_HEAD]
+    dtype: float16
+
+inits:
+  - dim: BATCH_SIZE
+  - dim: SEQ_LENGTH
+  - dim: N_HEADS
+  - dim: D_HEAD
+  - dim: D_STATE
+  - dim: BLOCK_LEN
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQ_LENGTH: 32
+      N_HEADS: 2
+      D_HEAD: 32
+      D_STATE: 8
+      BLOCK_LEN: 32

--- a/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
+++ b/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
@@ -1,0 +1,19 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, SEQUENCE_LENGTH, N_EMBD]
+    dtype: float16
+
+inits:
+  - dim: N_EMBD
+  - dim: N_HEAD
+  - dim: MAX_SEQLEN
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      SEQUENCE_LENGTH: 32
+      N_EMBD: 48
+      N_HEAD: 2
+      MAX_SEQLEN: 32

--- a/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
+++ b/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
@@ -1,0 +1,17 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: NUM_CLASSES
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      INPUT_CHANNELS: 3
+      HEIGHT: 56
+      WIDTH: 56
+      NUM_CLASSES: 2

--- a/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
+++ b/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
@@ -1,0 +1,20 @@
+inputs:
+  X:
+    shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
+    dtype: float16
+
+inits:
+  - dim: IN_CHANNELS
+  - dim: OUT_CHANNELS
+  - dim: STRIDE
+
+ci:
+  - params: [X]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 1
+      IN_CHANNELS: 3
+      OUT_CHANNELS: 4
+      HEIGHT: 56
+      WIDTH: 56
+      STRIDE: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "PyYAML",
   "numpy",
   "python-dotenv",
+  "einops",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Adds remaining level3 specs in CI variant.
'einops' is added as dependency as it is required by kernel l3/48.

Kernels level3 11 and 12 are disabled for now as their computation takes too long for local testing.