### PR TITLE
[harness] Support integer inputs

### DIFF
--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -9,6 +9,9 @@ from .specs import get_inputs
 from .specs import get_mem_bytes
 from .specs import get_torch_dtype
 from .specs import get_variant_torch_dtype
+from .specs import input_is_float
+from .specs import input_is_int
+from .specs import input_range
 from .specs import input_shape
 from .specs import input_torch_dtype
 
@@ -24,6 +27,9 @@ __all__ = [
     "get_mem_bytes",
     "get_torch_dtype",
     "get_variant_torch_dtype",
+    "input_is_float",
+    "input_is_int",
+    "input_range",
     "input_shape",
     "input_torch_dtype",
 ]

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -22,6 +22,7 @@ class InKey(StrEnum):
 
     SHAPE = "shape"
     TYPE = "dtype"
+    RANGE = "range"
 
 
 class InitKey(StrEnum):
@@ -81,6 +82,46 @@ def input_torch_dtype(input_entry: dict) -> torch.dtype:
     return get_torch_dtype(input_entry[InKey.TYPE])
 
 
+def input_is_float(input_entry: dict) -> bool:
+    """Check if an input is of floating point type.
+    Args:
+        input_entry: Specs' input entry
+    Returns:
+        True if type is of a floating point type
+    """
+    return "float" in input_entry[InKey.TYPE]
+
+
+def input_is_int(input_entry: dict) -> bool:
+    """Check an input is of integer type.
+    Args:
+        input_entry: Specs' input entry
+    Returns:
+        True if type is of an integer type
+    """
+    return "int" in input_entry[InKey.TYPE]
+
+
+def input_range(variant: dict, input_entry: dict) -> list[float, float]:
+    """Get input's values range.
+    Args:
+        variant: Specs' variant entry
+        input_entry: Specs' input entry
+    Returns:
+        Values range for the input: [low, high]
+    """
+    entry_range = input_entry[InKey.RANGE]
+    assert len(entry_range) == 2, "Expected range with two values [low, high]"
+    dims = variant[VKey.DIMS]
+
+    def get_range_value(val: str | float) -> float:
+        if isinstance(val, (int, float)):
+            return val
+        return dims[val]
+
+    return [get_range_value(val) for val in entry_range]
+
+
 def get_inputs(
     variant: dict, inputs: dict, device: torch.device | None = None
 ) -> list[torch.Tensor]:
@@ -97,7 +138,6 @@ def get_inputs(
     vals = []
     for param in variant[VKey.PARAMS]:
         input_entry = inputs[param]
-        assert "float" in input_entry[InKey.TYPE], "Only floating type is supported now"
         shape = input_shape(input_entry, dims)
         dtype = input_torch_dtype(input_entry)
         if variant_dtype is not None and dtype != variant_dtype:
@@ -107,7 +147,14 @@ def get_inputs(
                 UserWarning,
                 stacklevel=2,
             )
-        tensor = torch.randn(shape, dtype=dtype, device=device)
+        if input_is_float(input_entry):
+            tensor = torch.randn(shape, dtype=dtype, device=device)
+        elif input_is_int(input_entry):
+            value_range = input_range(variant, input_entry)
+            value_range = list(map(int, value_range))
+            tensor = torch.randint(*value_range, shape, dtype=dtype, device=device)
+        else:
+            raise TypeError("Only floating and integer types are supported now")
         vals.append(tensor)
     return vals
 

--- a/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
+++ b/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
@@ -1,0 +1,17 @@
+inputs:
+  predictions:
+    shape: [BATCH_SIZE, NUM_CLASSES]
+    dtype: float16
+  targets:
+    shape: [BATCH_SIZE]
+    dtype: int64
+    range: [0, NUM_CLASSES]
+
+inits: []
+
+ci:
+  - params: [predictions, targets]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      NUM_CLASSES: 8

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -11,6 +11,85 @@ from ai_bench.harness import core as ai_hc
 class TestDtypeMismatchWarning:
     """Tests for dtype mismatch warning in get_inputs."""
 
+    def test_input_int_ranges(self):
+        """Test integer inputs with various value ranges."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X", "Y", "Z"],
+            ai_hc.VKey.DIMS: {"BATCH": 2, "IN_FEAT": 16},
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["BATCH"],
+                ai_hc.InKey.TYPE: "int64",
+                ai_hc.InKey.RANGE: [1, 5],
+            },
+            "Y": {
+                ai_hc.InKey.SHAPE: ["IN_FEAT"],
+                ai_hc.InKey.TYPE: "int32",
+                ai_hc.InKey.RANGE: ["BATCH", 7],
+            },
+            "Z": {
+                ai_hc.InKey.SHAPE: ["BATCH"],
+                ai_hc.InKey.TYPE: "int16",
+                ai_hc.InKey.RANGE: ["BATCH", "IN_FEAT"],
+            },
+            "INVALID_RANGE": {
+                ai_hc.InKey.SHAPE: ["BATCH"],
+                ai_hc.InKey.TYPE: "int64",
+                ai_hc.InKey.RANGE: [3, 6, 9],
+            },
+        }
+
+        assert ai_hc.input_range(variant, inputs["X"]) == [1, 5]
+        assert ai_hc.input_range(variant, inputs["Y"]) == [2, 7]
+        assert ai_hc.input_range(variant, inputs["Z"]) == [2, 16]
+
+        with pytest.raises(Exception):
+            ai_hc.input_range(variant, inputs["INVALID_RANGE"])
+
+        inputs = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert len(inputs) == 3
+        assert inputs[0].dtype == torch.int64
+        assert inputs[1].dtype == torch.int32
+        assert inputs[2].dtype == torch.int16
+
+    def test_input_data_types(self):
+        """Test inputs with various data types."""
+        float_param = "T_FLOAT"
+        int_param = "T_INT"
+
+        variant = {
+            ai_hc.VKey.PARAMS: [float_param, int_param],
+            ai_hc.VKey.DIMS: {"BATCH": 2, "IN_FEAT": 8},
+        }
+        inputs = {
+            float_param: {
+                ai_hc.InKey.SHAPE: ["BATCH", "IN_FEAT"],
+                ai_hc.InKey.TYPE: "bfloat16",
+            },
+            int_param: {
+                ai_hc.InKey.SHAPE: ["BATCH"],
+                ai_hc.InKey.TYPE: "int64",
+                ai_hc.InKey.RANGE: [0, "IN_FEAT"],
+            },
+        }
+
+        input_float = inputs[float_param]
+        assert ai_hc.input_is_float(input_float)
+        assert not ai_hc.input_is_int(input_float)
+
+        input_int = inputs[int_param]
+        assert not ai_hc.input_is_float(input_int)
+        assert ai_hc.input_is_int(input_int)
+
+        int_range = ai_hc.input_range(variant, input_int)
+        assert int_range == [0, 8]
+
+        inputs = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert len(inputs) == 2
+        assert inputs[0].dtype == torch.bfloat16
+        assert inputs[1].dtype == torch.int64
+
     def test_warns_on_dtype_mismatch(self):
         """Test that warning is raised when input dtype differs from variant dtype."""
         variant = {


### PR DESCRIPTION
Adds support for integer inputs in problem specs.
A new spec input key 'range' is added to expose control over integer data initialization values.

Integer inputs require the new range specifier that sets boundaries for random initialization within provided low (inclusive) and high (exclusive) values.