### PR TITLE
[harness][runner] Kernel runner

### DIFF
--- a/ai_bench/harness/runner/__init__.py
+++ b/ai_bench/harness/runner/__init__.py
@@ -1,9 +1,13 @@
-from .kernel_bench_runner import FlopsUnit
+from .config import FlopsUnit
+from .config import MemBwUnit
 from .kernel_bench_runner import KernelBenchRunner
-from .kernel_bench_runner import MemBwUnit
+from .kernel_runner import KernelRunner
+from .kernel_runner import KernelStats
 
 __all__ = [
     "FlopsUnit",
     "KernelBenchRunner",
+    "KernelRunner",
+    "KernelStats",
     "MemBwUnit",
 ]

--- a/ai_bench/harness/runner/config.py
+++ b/ai_bench/harness/runner/config.py
@@ -1,0 +1,21 @@
+from enum import StrEnum
+
+
+class FlopsUnit(StrEnum):
+    """Control FLOPS measurement unit."""
+
+    TFLOPS = "TFLOPS"
+    GFLOPS = "GFLOPS"
+
+
+class MemBwUnit(StrEnum):
+    """Control memory bandwidth unit."""
+
+    GBS = "GB/s"
+    MBS = "MB/s"
+
+
+class NotesSymbols(StrEnum):
+    """Notes annotation symbols."""
+
+    ESTIMATE = "⚠️"

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -1,41 +1,18 @@
-from collections.abc import Callable
-from enum import StrEnum
 import json
 import os
 from pathlib import Path
-import types
 
 import torch
-import yaml
 
+from . import config
+from .kernel_runner import KernelRunner
+from .kernel_runner import KernelStats
 from ai_bench import utils as ai_utils
 from ai_bench.harness import core as ai_hc
-from ai_bench.harness import testing
 from ai_bench.utils.csv_logger import CSVLogger
-from ai_bench.utils.logger import setup_logger
 
 
-class FlopsUnit(StrEnum):
-    """Control FLOPS measurement unit."""
-
-    TFLOPS = "TFLOPS"
-    GFLOPS = "GFLOPS"
-
-
-class MemBwUnit(StrEnum):
-    """Control memory bandwidth unit."""
-
-    GBS = "GB/s"
-    MBS = "MB/s"
-
-
-class NotesSymbols(StrEnum):
-    """Notes annotation symbols."""
-
-    ESTIMATE = "⚠️"
-
-
-class KernelBenchRunner:
+class KernelBenchRunner(KernelRunner):
     """
     Run KernelBench problems.
 
@@ -53,16 +30,19 @@ class KernelBenchRunner:
         spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_CI,
         device: torch.device | None = None,
         backend: ai_hc.Backend = ai_hc.Backend.PYTORCH,
-        flops_unit: FlopsUnit = FlopsUnit.TFLOPS,
-        mem_bw_unit: MemBwUnit = MemBwUnit.GBS,
+        flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,
+        mem_bw_unit: config.MemBwUnit = config.MemBwUnit.GBS,
         csv_path: str | None = None,
         note: str = "",
     ):
+        super().__init__(
+            spec_type=spec_type,
+            device=device,
+            backend=backend,
+            flops_unit=flops_unit,
+            mem_bw_unit=mem_bw_unit,
+        )
         self.specs = ai_utils.specs() / "KernelBench"
-        self.backend = backend
-        self.logger = setup_logger()
-        self.flops_unit = flops_unit
-        self.mem_bw_unit = mem_bw_unit
         self.csv_path = csv_path
         self.note = note
         self.csv_fieldnames = [
@@ -106,25 +86,6 @@ class KernelBenchRunner:
                 f"Missing kernels directory for {self.backend}: {self.kernels}"
             )
 
-        self.spec_type = spec_type
-        self.device = device if device else torch.device("cpu")
-        if self.device.type == "cpu":
-            self.warmup = 5
-            self.rep = 20
-        elif self.device.type == "xpu":
-            self.warmup = 200
-            self.rep = 100
-        else:
-            self.warmup = 25
-            self.rep = 100
-
-    def is_torch_backend(self) -> bool:
-        """Check if the backend is a torch variant.
-        Returns:
-            True if the current backend is torch-based.
-        """
-        return self.backend in [ai_hc.Backend.PYTORCH, ai_hc.Backend.PYTORCH_COMPILE]
-
     def get_spec_dirs(self) -> list[Path]:
         """Get KernelBench level dirs.
         Returns:
@@ -134,165 +95,50 @@ class KernelBenchRunner:
             [Path(entry) for entry in os.scandir(self.specs) if entry.is_dir()]
         )
 
-    def load_model(self, kernel_path: Path) -> types.ModuleType | None:
-        """Load KernelBench model.
-        All kernel modules are standarized with a class wrapper containing
-        computation definition and a runner method.
-        These models can be imported and used directly by the runner.
-        Args:
-            kernel_path: Path to KernelBench module '.py' file
-        Returns:
-            Loaded KernelBench model if available
-        """
-        if not kernel_path.is_file():
-            return None
-        mod = ai_utils.import_from_path("kernel_bench_model", kernel_path)
-        if not hasattr(mod, "Model"):
-            return None
-        return mod.Model
-
-    def print_info_legend(self, print_fn: Callable):
-        """Print information legend.
-        Args:
-            print_fn: Callback to a printing function
-        """
-        print_fn("Legend:")
-        print_fn(f"  - {NotesSymbols.ESTIMATE} : Estimated value")
-
     def run_kernels(self):
         """Run all KernelBench kernels."""
-        self.logger.info(f"Backend: {self.backend}, Device: {self.device}")
         self.logger.info(f"Kernels: {self.kernels}")
-        self.print_info_legend(self.logger.info)
-        self.logger.info("-" * 60)
+        self.print_info(self.logger.info)
 
         # Iterate over specs of kernel levels.
         for spec_dir in self.get_spec_dirs():
             # Iterate over specs - one per kernel.
             for file in sorted(os.listdir(spec_dir)):
-                with open(spec_dir / file) as f:
-                    spec = yaml.safe_load(f)
-                # Skip if desired configuration is not available.
-                if self.spec_type not in spec:
-                    continue
-                variants = spec[self.spec_type]
-                inputs = spec[ai_hc.SpecKey.INS]
-                inits = []
-                if ai_hc.SpecKey.INITS in spec:
-                    inits = spec[ai_hc.SpecKey.INITS]
-
-                # Import kernel file to access underlying Model and execution method.
                 # Spec and kernel file names are expected to be identical.
                 kernel_dir = self.kernels / spec_dir.name
                 kernel_file = Path(kernel_dir / file.replace(".yaml", ".py"))
-                model_obj = self.load_model(kernel_file)
-                if not model_obj:
-                    self.logger.debug(f"Missing kernel for: {file}")
+
+                # Run the kernel in all compatible variants.
+                run_stats: list[KernelStats] | None = self.run_kernel_specs(
+                    kernel_file, spec_dir / file
+                )
+
+                # Continue if desired configuration is not available or
+                # if there is nothing extra to report.
+                if not run_stats:
                     continue
-                # Run the kernel with provided input configurations.
-                self.logger.info(f"Kernel: {spec_dir.name} / {file} [{self.backend}]")
-                for variant in variants:
-                    model_inits = ai_hc.get_inits(variant, inits)
-                    model_dtype = ai_hc.get_variant_torch_dtype(variant)
-                    base_model = model_obj(*model_inits).to(
-                        self.device, dtype=model_dtype
-                    )
-                    model = base_model
 
-                    if self.backend == ai_hc.Backend.PYTORCH_COMPILE:
-                        model = torch.compile(model, dynamic=False)
-
-                    fn = model.forward
-                    args = ai_hc.get_inputs(variant, inputs, device=self.device)
-
-                    # Simple CI run to verify functionality.
-                    if self.spec_type == ai_hc.SpecKey.V_CI:
-                        self.logger.info(f"Validating: {variant}")
-                        fn(*args)
-                        continue
-
-                    self.logger.info(f"Benchmarking: {variant}")
-                    meas_us = testing.time(
-                        fn, args, warmup=self.warmup, rep=self.rep, device=self.device
-                    )
-
-                    # Statistics - FLOPs.
-                    flop = ai_hc.get_flop(variant)
-                    flop_is_estimate = False
-                    if not flop and self.is_torch_backend():
-                        flop = ai_utils.count_torch_flop(fn, args)
-                        flop_is_estimate = True
-
-                    flops_val = ""
-                    flops_unit = ""
-                    flops_note = ""
-                    if flop:
-                        tflops = flop / meas_us / 1e6
-                        match self.flops_unit:
-                            case FlopsUnit.TFLOPS:
-                                flops_val = tflops
-                            case FlopsUnit.GFLOPS:
-                                flops_val = tflops * 1000
-                            case _:
-                                raise ValueError(
-                                    f"Invalid FLOPS unit: {self.flops_unit}"
-                                )
-                        flops_unit = str(self.flops_unit)
-                        if flop_is_estimate:
-                            flops_note = NotesSymbols.ESTIMATE
-
-                    self.logger.info(
-                        f"  time [us]: {meas_us:.6f} {flops_unit}: {flops_val} {flops_note}"
-                    )
-
-                    # Statistics - memory bandwidth.
-                    mem_bytes = ai_hc.get_mem_bytes(variant)
-                    mem_is_estimate = False
-                    if not mem_bytes and self.is_torch_backend():
-                        mem_bytes = ai_utils.count_torch_memory_bytes(base_model, args)
-                        mem_is_estimate = True
-
-                    mem_bw_val = ""
-                    mem_bw_unit = ""
-                    mem_note = ""
-                    if mem_bytes:
-                        gbs = mem_bytes / meas_us / 1e3
-                        match self.mem_bw_unit:
-                            case MemBwUnit.GBS:
-                                mem_bw_val = gbs
-                            case MemBwUnit.MBS:
-                                mem_bw_val = gbs * 1000
-                            case _:
-                                raise ValueError(
-                                    f"Invalid memory bandwidth unit: {self.mem_bw_unit}"
-                                )
-                        mem_bw_unit = str(self.mem_bw_unit)
-                        if mem_is_estimate:
-                            mem_note = NotesSymbols.ESTIMATE
-
-                        self.logger.info(f"  {mem_bw_unit}: {mem_bw_val} {mem_note}")
-
-                    if self.csv_logger:
-                        aibench_env = {
-                            k: v
-                            for k, v in os.environ.items()
-                            if k.startswith("AIBENCH_")
-                        }
+                if self.csv_logger:
+                    # Log all executed variants.
+                    aibench_env = {
+                        k: v for k, v in os.environ.items() if k.startswith("AIBENCH_")
+                    }
+                    for run in run_stats:
                         row = {
                             "kernel_name": file,
                             "kernel_type": str(self.backend),
                             "problem_level": spec_dir.name,
-                            "flops": flop if flop is not None else "",
-                            "flops_val": flops_val,
-                            "flops_unit": flops_unit,
-                            "flops_note": flops_note,
-                            "mem_bytes": mem_bytes if mem_bytes is not None else "",
-                            "mem_bw_val": mem_bw_val,
-                            "mem_bw_unit": mem_bw_unit,
-                            "mem_note": mem_note,
-                            "time_us": meas_us,
+                            "flops": str(run.flop or ""),
+                            "flops_val": str(run.flops or ""),
+                            "flops_unit": str(run.flops_unit or ""),
+                            "flops_note": str(run.flops_note or ""),
+                            "mem_bytes": str(run.mem_bytes or ""),
+                            "mem_bw_val": str(run.mem_bw or ""),
+                            "mem_bw_unit": str(run.mem_bw_unit or ""),
+                            "mem_note": str(run.mem_note or ""),
+                            "time_us": run.meas_us,
                             "input_values": json.dumps(
-                                variant.get(ai_hc.VKey.DIMS, {})
+                                run.variant.get(ai_hc.VKey.DIMS, {})
                             ),
                             "note": self.note,
                         }

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -1,0 +1,264 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+import types
+
+import torch
+import yaml
+
+from . import config
+from ai_bench import utils as ai_utils
+from ai_bench.harness import core as ai_hc
+from ai_bench.harness import testing
+from ai_bench.utils.logger import setup_logger
+
+
+@dataclass
+class KernelStats:
+    """
+    Kernel execution statistics.
+
+    Args:
+        variant: Specs' variant entry
+        meas_us: Mean runtime in microseconds
+        flop: Number of floating point operations (FLOP)
+        flops: FLOP per second (FLOPS)
+        flops_unit: FLOPS measurement unit
+        flops_note: FLOPS annotation
+        mem_bytes: Number of memory access bytes
+        mem_bw: Memory bandwidth
+        mem_bw_unit: Memory bandwidth measurement unit
+        mem_note: Memory bandwidth annotation
+    """
+
+    variant: dict
+    meas_us: float
+    flop: float | None
+    flops: float | None
+    flops_unit: config.FlopsUnit
+    flops_note: config.NotesSymbols | None
+    mem_bytes: float | None
+    mem_bw: float | None
+    mem_bw_unit: config.MemBwUnit
+    mem_note: config.NotesSymbols | None
+
+
+class KernelRunner:
+    """
+    Run a kernel problem.
+
+    The kernel implementatation is expected to be wrapped in 'torch.nn.Module'
+    and invoked in its 'forward' method.
+
+    Args:
+        spec_type: Type of problem spec to use
+        device: Device to use
+        backend: Backend to use
+        flops_unit: FLOPS unit to use for reporting
+        csv_path: Path to CSV file for logging (optional)
+        note: Optional note to include in CSV
+    """
+
+    def __init__(
+        self,
+        spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_CI,
+        device: torch.device | None = None,
+        backend: ai_hc.Backend = ai_hc.Backend.PYTORCH,
+        flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,
+        mem_bw_unit: config.MemBwUnit = config.MemBwUnit.GBS,
+    ):
+        self.backend = backend
+        self.logger = setup_logger()
+        self.flops_unit = flops_unit
+        self.mem_bw_unit = mem_bw_unit
+
+        self.spec_type = spec_type
+        self.device = device if device else torch.device("cpu")
+        if self.device.type == "cpu":
+            self.warmup = 5
+            self.rep = 20
+        elif self.device.type == "xpu":
+            self.warmup = 200
+            self.rep = 100
+        else:
+            self.warmup = 25
+            self.rep = 100
+
+    def is_torch_backend(self) -> bool:
+        """Check if the backend is a torch variant.
+        Returns:
+            True if the current backend is torch-based.
+        """
+        return self.backend in [ai_hc.Backend.PYTORCH, ai_hc.Backend.PYTORCH_COMPILE]
+
+    def load_model(self, kernel_path: Path) -> types.ModuleType | None:
+        """Load a kernel model.
+
+        All kernel modules are standarized with a class wrapper containing
+        computation definition and a runner method.
+        These models can be imported and used directly by the runner.
+
+        Args:
+            kernel_path: Path to PyTorch module '.py' file
+        Returns:
+            Loaded model if available
+        """
+        if not kernel_path.is_file():
+            return None
+        mod = ai_utils.import_from_path("kernel_model", kernel_path)
+        if not hasattr(mod, "Model"):
+            return None
+        return mod.Model
+
+    def print_info_legend(self, print_fn: Callable):
+        """Print information legend.
+        Args:
+            print_fn: Callback to a printing function
+        """
+        print_fn("Legend:")
+        print_fn(f"  - {config.NotesSymbols.ESTIMATE} : Estimated value")
+
+    def print_info(self, print_fn: Callable | None = None):
+        """Print general runner info.
+        Args:
+            print_fn: Callback to a printing function.
+                Defaults to an INFO logger.
+        """
+        if not print_fn:
+            print_fn = self.logger.info
+
+        print_fn(f"Backend: {self.backend}, Device: {self.device}")
+        print_fn(f"Problem spec: {self.spec_type}")
+        self.print_info_legend(print_fn)
+        print_fn("-" * 60)
+
+    def run_kernel_specs(
+        self, kernel_path: Path, spec_path: Path
+    ) -> list[KernelStats] | None:
+        """Run a kernel in all variants.
+        Args:
+            kernel_path: Path to kernel wrapped in PyTorch module '.py' file
+            spec_path: Path to problem spec '.yaml' file
+        Returns:
+            Kernel statistics for all benchmarked variants.
+            No statistics are available for CI spec.
+            None is returned when execution is unsuccessful.
+        """
+
+        with open(spec_path) as f:
+            spec = yaml.safe_load(f)
+        # Bail if desired configuration is not available.
+        if self.spec_type not in spec:
+            return None
+        variants = spec[self.spec_type]
+        inputs = spec[ai_hc.SpecKey.INS]
+        inits = []
+        if ai_hc.SpecKey.INITS in spec:
+            inits = spec[ai_hc.SpecKey.INITS]
+
+        # Import kernel file to access underlying Model and execution method.
+        model_obj = self.load_model(kernel_path)
+        if not model_obj:
+            self.logger.debug(f"Missing kernel for: {kernel_path.name}")
+            return None
+
+        # Run the kernel with provided input configurations.
+        self.logger.info(
+            f"Kernel: {spec_path.parent.name} / {spec_path.name} [{self.backend}]"
+        )
+        stats = []
+        for variant in variants:
+            model_inits = ai_hc.get_inits(variant, inits)
+            model_dtype = ai_hc.get_variant_torch_dtype(variant)
+            base_model = model_obj(*model_inits).to(self.device, dtype=model_dtype)
+            model = base_model
+
+            if self.backend == ai_hc.Backend.PYTORCH_COMPILE:
+                model = torch.compile(model, dynamic=False)
+
+            fn = model.forward
+            args = ai_hc.get_inputs(variant, inputs, device=self.device)
+
+            # Simple CI run to verify functionality.
+            if self.spec_type == ai_hc.SpecKey.V_CI:
+                self.logger.info(f"Validating: {variant}")
+                fn(*args)
+                continue
+
+            self.logger.info(f"Benchmarking: {variant}")
+            meas_us = testing.time(
+                fn, args, warmup=self.warmup, rep=self.rep, device=self.device
+            )
+
+            # Statistics - FLOPs.
+            flop = ai_hc.get_flop(variant)
+            flop_is_estimate = False
+            if not flop and self.is_torch_backend():
+                flop = ai_utils.count_torch_flop(fn, args)
+                flop_is_estimate = True
+
+            flops_val = None
+            flops_unit = None
+            flops_note = None
+            if flop:
+                tflops = flop / meas_us / 1e6
+                match self.flops_unit:
+                    case config.FlopsUnit.TFLOPS:
+                        flops_val = tflops
+                    case config.FlopsUnit.GFLOPS:
+                        flops_val = tflops * 1000
+                    case _:
+                        raise ValueError(f"Invalid FLOPS unit: {self.flops_unit}")
+                flops_unit = str(self.flops_unit)
+                if flop_is_estimate:
+                    flops_note = config.NotesSymbols.ESTIMATE
+
+            self.logger.info(
+                f"  time [us]: {meas_us:.6f} {str(flops_unit or '')}: {str(flops_val or '')} {str(flops_note or '')}"
+            )
+
+            # Statistics - memory bandwidth.
+            mem_bytes = ai_hc.get_mem_bytes(variant)
+            mem_is_estimate = False
+            if not mem_bytes and self.is_torch_backend():
+                mem_bytes = ai_utils.count_torch_memory_bytes(base_model, args)
+                mem_is_estimate = True
+
+            mem_bw_val = None
+            mem_bw_unit = None
+            mem_note = None
+            if mem_bytes:
+                gbs = mem_bytes / meas_us / 1e3
+                match self.mem_bw_unit:
+                    case config.MemBwUnit.GBS:
+                        mem_bw_val = gbs
+                    case config.MemBwUnit.MBS:
+                        mem_bw_val = gbs * 1000
+                    case _:
+                        raise ValueError(
+                            f"Invalid memory bandwidth unit: {self.mem_bw_unit}"
+                        )
+                mem_bw_unit = str(self.mem_bw_unit)
+                if mem_is_estimate:
+                    mem_note = config.NotesSymbols.ESTIMATE
+
+                self.logger.info(
+                    f"  {str(mem_bw_unit or '')}: {str(mem_bw_val or '')} {str(mem_note or '')}"
+                )
+
+            kernel_stats = KernelStats(
+                variant=variant,
+                meas_us=meas_us,
+                flop=flop,
+                flops=flops_val,
+                flops_unit=flops_unit,
+                flops_note=flops_note,
+                mem_bytes=mem_bytes,
+                mem_bw=mem_bw_val,
+                mem_bw_unit=mem_bw_unit,
+                mem_note=mem_note,
+            )
+            stats.append(kernel_stats)
+
+        # Report statistics for all variants
+        return stats


### PR DESCRIPTION
Moves kernel execution logic out of KernelBench runner into a separate runner submodule.
Config enums are also moved into a separate submodule.

The separation keeps KernelBench details like finding specs and creating a CSV report in the existing module.
The new runner still expects any kernel implementation to be wrapped in PyTorch nn.Module.