### PR TITLE
[CLI] Run a custom kernel with a spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml
 import ai_bench
 import torch
 
-# Create a single Kernel benchmark
+# Create a single kernel benchmark
 kernel_runner = ai_bench.KernelRunner(
     spec_type=ai_bench.SpecKey.V_BENCH_CPU,
     device=torch.device("cpu"),

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ ai-bench --xpu --bench
 
 # Log results to CSV
 ai-bench --xpu --bench --csv results.csv --note "baseline run"
+
+# Run a single kernel with a problem specification
+ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml
 ```
 
 ### As a Library
@@ -65,14 +68,24 @@ ai-bench --xpu --bench --csv results.csv --note "baseline run"
 import ai_bench
 import torch
 
+# Create a single Kernel benchmark
+kernel_runner = ai_bench.KernelRunner(
+    spec_type=ai_bench.SpecKey.V_BENCH_CPU,
+    device=torch.device("cpu"),
+    backend=ai_bench.Backend.PYTORCH,
+    flops_unit=ai_bench.FlopsUnit.TFLOPS,
+    mem_bw_unit=ai_bench.MemBwUnit.GBS,
+)
+kernel_runner.run_kernel_spec("path/to/kernel.py", "path/to/spec.yaml")
+
 # Configure paths if running outside project root
 ai_bench.configure(
     specs_dir="/path/to/specs",
     kernels_dir="/path/to/kernels",
 )
 
-# Create benchmark runner
-runner = ai_bench.KernelBenchRunner(
+# Create KernelBench benchmark runner
+kb_runner = ai_bench.KernelBenchRunner(
     spec_type=ai_bench.SpecKey.V_BENCH_GPU,
     device=torch.device("xpu"),
     backend=ai_bench.Backend.PYTORCH,
@@ -80,7 +93,7 @@ runner = ai_bench.KernelBenchRunner(
     mem_bw_unit=ai_bench.MemBwUnit.GBS,
     csv_path="results.csv",
 )
-runner.run_kernels()
+kb_runner.run_kernels()
 ```
 
 ### CSV Logging
@@ -129,9 +142,10 @@ Notes legend:
 
 | Option | Description |
 |--------|-------------|
+| `--kernel KERNEL_PATH SPEC_PATH` | Run a kernel with a spec (default: KernelBench) |
 | `--xpu` | Run on Intel XPU (default: CPU) |
-| `--triton` | Use Triton backend (default: PyTorch) |
-| `--torch-compile` | Use PyTorch compile mode |
+| `--triton` | Use Triton backend (default: PyTorch eager) |
+| `--torch-compile` | Use PyTorch compile mode (default: PyTorch eager) |
 | `--bench` | Run benchmarks with timing (default: CI validation) |
 | `--gflops` | Report GFLOPS (default: TFLOPS) |
 | `--mbs` | Report MB/s (default: GB/s) |
@@ -139,6 +153,10 @@ Notes legend:
 | `--note TEXT` | Add a note to CSV output for identifying runs |
 | `--specs-dir PATH` | Path to specs directory (CLI only) |
 | `--kernels-dir PATH` | Path to kernels directory (CLI only) |
+| `--triton-kernels-dir PATH` | Path to Triton kernels directory (CLI only) |
+| `--helion-kernels-dir PATH` | Path to Helion kernels directory (CLI only) |
+| `--env-file PATH` | Path to .env file (default: auto-detect) |
+| `--no-env` | Disable loading .env config |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
 # Run a single kernel with a problem specification
 ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml
+
+# Run a single kernel with a problem specification on XPU
+ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml --xpu
 ```
 
 ### As a Library

--- a/ai_bench/__init__.py
+++ b/ai_bench/__init__.py
@@ -52,6 +52,7 @@ from ai_bench.harness.core import input_torch_dtype
 # Runner
 from ai_bench.harness.runner import FlopsUnit
 from ai_bench.harness.runner import KernelBenchRunner
+from ai_bench.harness.runner import KernelRunner
 from ai_bench.harness.runner import MemBwUnit
 
 # Timing utilities
@@ -73,6 +74,7 @@ __all__ = [
     "InKey",
     "InitKey",
     "KernelBenchRunner",
+    "KernelRunner",
     "MemBwUnit",
     "SpecKey",
     "VKey",

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -38,7 +38,13 @@ Examples:
   # Save results to CSV
   ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
-  # Use custom paths (for library-style usage)
+  # Run a single kernel with a spec
+  ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml
+
+  # Run a single kernel with a spec on XPU
+  ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml --xpu
+
+  # Use custom KernelBench paths (for library-style usage)
   ai-bench --specs-dir /path/to/specs --kernels-dir /path/to/kernels
 
   # Use specific .env file
@@ -59,6 +65,17 @@ Environment file (.env) example:
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
+    )
+
+    # Runner options
+    runner_group = parser.add_argument_group("runner options")
+    runner_group.add_argument(
+        "--kernel",
+        nargs=2,
+        type=Path,
+        default=None,
+        help="Paths to kernel .py and specs .yaml files to run (default: KernelBench runner)",
+        metavar=("KERNEL_PATH", "SPEC_PATH"),
     )
 
     # Environment file options
@@ -251,6 +268,31 @@ def main(argv: list[str] | None = None) -> int:
     mem_bw_unit = runner.MemBwUnit.MBS if args.mbs else runner.MemBwUnit.GBS
 
     try:
+        if args.kernel:
+            # Paths pre-validation
+            kernel_path: Path = args.kernel[0]
+            if kernel_path.suffix != ".py":
+                print(
+                    f"Expected .py kernel file but got: {kernel_path}", file=sys.stderr
+                )
+                return 1
+            spec_path: Path = args.kernel[1]
+            if spec_path.suffix != ".yaml":
+                print(f"Expected .yaml spec file but got: {spec_path}", file=sys.stderr)
+                return 1
+
+            # Run a single kernel
+            kernel_runner = runner.KernelRunner(
+                spec_type=spec_type,
+                device=device,
+                backend=backend,
+                flops_unit=flops_unit,
+                mem_bw_unit=mem_bw_unit,
+            )
+            kernel_runner.run_kernel_spec(kernel_path, spec_path)
+            return 0
+
+        # Run KernelBench problems
         kb_runner = runner.KernelBenchRunner(
             spec_type=spec_type,
             device=device,

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -276,9 +276,16 @@ def main(argv: list[str] | None = None) -> int:
                     f"Expected .py kernel file but got: {kernel_path}", file=sys.stderr
                 )
                 return 1
+            if not kernel_path.exists():
+                print(f"Kernel path not found: {kernel_path}", file=sys.stderr)
+                return 1
+
             spec_path: Path = args.kernel[1]
             if spec_path.suffix != ".yaml":
                 print(f"Expected .yaml spec file but got: {spec_path}", file=sys.stderr)
+                return 1
+            if not spec_path.exists():
+                print(f"Spec path not found: {spec_path}", file=sys.stderr)
                 return 1
 
             # Run a single kernel

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -109,7 +109,7 @@ class KernelBenchRunner(KernelRunner):
                 kernel_file = Path(kernel_dir / file.replace(".yaml", ".py"))
 
                 # Run the kernel in all compatible variants.
-                run_stats: list[KernelStats] | None = self.run_kernel_specs(
+                run_stats: list[KernelStats] | None = self.run_kernel_spec(
                     kernel_file, spec_dir / file
                 )
 

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -149,11 +149,6 @@ class KernelRunner:
         if isinstance(spec_path, str):
             spec_path = Path(spec_path)
 
-        if not kernel_path.exists():
-            raise FileNotFoundError(f"Kernel path not found: {kernel_path}")
-        if not spec_path.exists():
-            raise FileNotFoundError(f"Spec path not found: {spec_path}")
-
         with open(spec_path) as f:
             spec = yaml.safe_load(f)
         # Bail if desired configuration is not available.

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -132,10 +132,10 @@ class KernelRunner:
         self.print_info_legend(print_fn)
         print_fn("-" * 60)
 
-    def run_kernel_specs(
-        self, kernel_path: Path, spec_path: Path
+    def run_kernel_spec(
+        self, kernel_path: Path | str, spec_path: Path | str
     ) -> list[KernelStats] | None:
-        """Run a kernel in all variants.
+        """Run a kernel with a spec.
         Args:
             kernel_path: Path to kernel wrapped in PyTorch module '.py' file
             spec_path: Path to problem spec '.yaml' file
@@ -144,6 +144,15 @@ class KernelRunner:
             No statistics are available for CI spec.
             None is returned when execution is unsuccessful.
         """
+        if isinstance(kernel_path, str):
+            kernel_path = Path(kernel_path)
+        if isinstance(spec_path, str):
+            spec_path = Path(spec_path)
+
+        if not kernel_path.exists():
+            raise FileNotFoundError(f"Kernel path not found: {kernel_path}")
+        if not spec_path.exists():
+            raise FileNotFoundError(f"Spec path not found: {spec_path}")
 
         with open(spec_path) as f:
             spec = yaml.safe_load(f)

--- a/problems/specs/KernelBench/level1/33_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level1/33_BatchNorm.yaml
@@ -3,7 +3,8 @@ inputs:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
     dtype: float16
 
-inits: []
+inits:
+  - dim: FEATURES
 
 ci:
   - params: [x]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -546,6 +546,36 @@ class Model(torch.nn.Module):
             # Should initialize model with hidden_size=16.
             kb_runner.run_kernels()
 
+    def test_spec_without_kernel(self, temp_dirs):
+        """Test spec without a kernel."""
+        spec_content = """
+inputs:
+  X:
+    shape: [B, H]
+    dtype: float32
+inits:
+  - dim: H
+ci:
+  - params: [X]
+    dims:
+      B: 2
+      H: 16
+"""
+        self._create_spec_file(temp_dirs["specs"], "spec.yaml", spec_content)
+
+        with mock.patch(
+            "ai_bench.utils.finder.project_root", return_value=temp_dirs["root"]
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.PYTORCH,
+            )
+            # Should run without errors.
+            # When a spec has no corresponding kernel,
+            # this case is simply skipped.
+            kb_runner.run_kernels()
+
 
 class TestTimerFunctions:
     """Tests for timing functions."""


### PR DESCRIPTION
Adds a CLI option to run a single kernel with a spec file. Updates README and slightly refactors KernelRunner module.
Also, fixes broken l1/33 spec file.

By default, the KernelBench kernels are executed as before.
The provided files must follow the same convention as KernelBench setup. That is, the kernel must be wrapped in a `Model(torch.nn.Module)` and spec file uses the same syntax as other problems.