### PR TITLE
[harness] Dynamic custom input initializers

### DIFF
--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -1,3 +1,5 @@
+from .spec_inits import apply_scale
+from .spec_inits import apply_softmax
 from .specs import Backend
 from .specs import InitKey
 from .specs import InKey
@@ -22,6 +24,8 @@ __all__ = [
     "InitKey",
     "SpecKey",
     "VKey",
+    "apply_scale",
+    "apply_softmax",
     "get_flop",
     "get_inits",
     "get_inputs",

--- a/ai_bench/harness/core/spec_inits.py
+++ b/ai_bench/harness/core/spec_inits.py
@@ -1,0 +1,11 @@
+import torch
+
+
+def apply_scale(tensor: torch.Tensor, scale: float | None = None) -> torch.Tensor:
+    if scale is None:
+        scale = torch.rand(())
+    return tensor * scale
+
+
+def apply_softmax(tensor: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    return tensor.softmax(dim)

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -1,4 +1,9 @@
+from collections.abc import Callable
+from collections.abc import Sequence
 from enum import StrEnum
+from functools import lru_cache
+from pathlib import Path
+import types
 from typing import Dict
 import warnings
 
@@ -23,6 +28,15 @@ class InKey(StrEnum):
     SHAPE = "shape"
     TYPE = "dtype"
     RANGE = "range"
+    INIT = "init"
+
+
+class InInitKey(StrEnum):
+    """Keys for spec input initialization."""
+
+    FN = "fn"
+    ARGS = "args"
+    KWARGS = "kwargs"
 
 
 class InitKey(StrEnum):
@@ -132,6 +146,39 @@ def input_range(variant: dict, input_entry: dict) -> list[float, float]:
     return [get_range_value(val) for val in entry_range]
 
 
+@lru_cache(maxsize=None)
+def _load_spec_init_modules(module_paths: Sequence[Path]) -> Sequence[types.ModuleType]:
+    assert len(module_paths) > 0, "Expected at least one path to init module"
+
+    modules = []
+    for path in module_paths:
+        modules.append(utils.import_from_path(path.stem, path))
+    return modules
+
+
+@lru_cache(maxsize=None)
+def _input_init_fn(fn_name: str) -> Callable[..., torch.Tensor] | None:
+    modules = _load_spec_init_modules(utils.spec_inits())
+    for mod in modules:
+        if hasattr(mod, fn_name):
+            return getattr(mod, fn_name)
+    return None
+
+
+def initialize_input(
+    tensor: torch.Tensor, variant: dict, input_inits: list[dict]
+) -> torch.Tensor:
+    # TODO: remove debug prints
+    for init_entry in input_inits:
+        init_fn = _input_init_fn(init_entry[InInitKey.FN])
+        print(f"{init_fn}", flush=True)
+        # TODO: get spec args
+        # TODO: get spec kwargs
+        # TODO: substiture dim vars in the above
+        tensor = init_fn(tensor)
+    return tensor
+
+
 def get_inputs(
     variant: dict, inputs: dict, device: torch.device | None = None
 ) -> list[torch.Tensor]:
@@ -157,6 +204,7 @@ def get_inputs(
                 UserWarning,
                 stacklevel=2,
             )
+
         if input_is_float(input_entry):
             tensor = torch.randn(shape, dtype=dtype, device=device)
         elif input_is_int(input_entry):
@@ -167,6 +215,12 @@ def get_inputs(
             tensor = torch.randint(0, 2, shape, dtype=torch.int64, device=device).bool()
         else:
             raise TypeError("Only floating and integer types are supported now")
+
+        if InKey.INIT in input_entry:
+            # TODO: remove debug prints
+            print(f"input: {param}")
+            tensor = initialize_input(tensor, variant, input_entry[InKey.INIT])
+
         vals.append(tensor)
     return vals
 

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -6,6 +6,7 @@ from .finder import helion_kernels_dir
 from .finder import kernel_bench_dir
 from .finder import project_root
 from .finder import reset_configuration
+from .finder import spec_inits
 from .finder import specs
 from .finder import triton_kernels_dir
 from .flop_counter import count_torch_flop
@@ -26,6 +27,7 @@ __all__ = [
     "kernel_bench_dir",
     "project_root",
     "reset_configuration",
+    "spec_inits",
     "specs",
     "triton_kernels_dir",
 ]

--- a/ai_bench/utils/finder.py
+++ b/ai_bench/utils/finder.py
@@ -216,6 +216,39 @@ def specs() -> Path:
     return _get_path(_specs_dir, "AIBENCH_SPECS_DIR", default, "Specs directory")
 
 
+def spec_inits() -> frozenset[Path]:
+    """Path to problem spec initializer modules.
+
+    Can be configured via:
+    - ai_bench.configure(spec_inits_path=...)
+    - AIBENCH_SPEC_INITS_PATH environment variable
+    - Auto-detected from project structure
+
+    Returns:
+        Path to spec inits module files
+
+    Raises:
+        ConfigurationError: If path cannot be determined
+    """
+
+    def built_ins() -> set[Path]:
+        path = project_root() / "ai_bench" / "harness" / "core" / "spec_inits.py"
+        if not path.exists():
+            raise FileNotFoundError(f"Default specs path not found: {path}")
+        return set([path])
+
+    paths = built_ins()
+
+    extra_paths = _get_path(
+        _specs_dir, "AIBENCH_SPECS_DIR", lambda: None, "Spec inits path"
+    )
+    if extra_paths is not None:
+        for path in str(extra_paths).split(":"):
+            paths.add(Path(path))
+
+    return frozenset(paths)
+
+
 def kernel_bench_dir() -> Path:
     """Path to the KernelBench directory (PyTorch kernels).
 

--- a/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
+++ b/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
@@ -1,0 +1,21 @@
+inputs:
+  predictions:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+    init:
+      - fn: apply_scale
+      - fn: apply_softmax
+  targets:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+    init:
+      - fn: apply_softmax
+
+inits: []
+
+ci:
+  - params: [predictions, targets]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
+++ b/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
@@ -1,0 +1,23 @@
+inputs:
+  anchor:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+    init:
+      - fn: apply_scale
+  positive:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+  negative:
+    shape: [BATCH_SIZE, INPUT_DIM]
+    dtype: float16
+
+inits:
+  - dim: MARGIN
+
+ci:
+  - params: [anchor, positive, negative]
+    dtype: float16
+    dims:
+      BATCH_SIZE: 64
+      INPUT_DIM: 8
+      MARGIN: 1.0


### PR DESCRIPTION
Adds 'init' entry to spec's inputs that allows specifying a list of functions that get called sequentially to perform extra data initialization.