### PR TITLE
[CI] Propagate exit code

### DIFF
--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -75,4 +75,8 @@ if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_HELION}" ]]; then
 fi
 
 ${AI_BENCH_UV} run ai-bench ${BENCH_FLAGS}
+EXIT_CODE=$?
+
 echo ""
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
Fixes XPU runner script to propagate exit code to correctly report failures.