### PR TITLE
[harness] Spec input - inherit data type

### DIFF
--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -1,5 +1,6 @@
 from .specs import Backend
 from .specs import InInitKey
+from .specs import InInputKey
 from .specs import InitKey
 from .specs import InKey
 from .specs import SpecKey
@@ -21,6 +22,7 @@ from .specs import input_torch_dtype
 __all__ = [
     "Backend",
     "InInitKey",
+    "InInputKey",
     "InKey",
     "InitKey",
     "SpecKey",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
+from functools import cache
 from typing import Dict
-import warnings
 
 import torch
 
@@ -24,6 +24,12 @@ class InKey(StrEnum):
     TYPE = "dtype"
     RANGE = "range"
     INITS = "inits"
+
+
+class InInputKey(StrEnum):
+    """Keys for input type."""
+
+    INHERIT = "inherit"
 
 
 class InInitKey(StrEnum):
@@ -88,14 +94,25 @@ def get_torch_dtype(dtype: str) -> torch.dtype:
     return dtp
 
 
-def input_torch_dtype(input_entry: dict) -> torch.dtype:
+def input_torch_dtype(input_entry: dict, variant: dict | None = None) -> torch.dtype:
     """Get torch data type for an input.
     Args:
         input_entry: Specs' input entry
+        variant: Optional specs' variant entry
     Returns:
         torch data type
     """
-    return get_torch_dtype(input_entry[InKey.TYPE])
+    in_type = input_entry[InKey.TYPE]
+    if in_type in InInputKey:
+        match InInputKey(in_type):
+            case InInputKey.INHERIT:
+                dtype = get_variant_torch_dtype(variant) if variant else None
+                if dtype is None:
+                    raise ValueError("Missing variant type for inheritance")
+                return dtype
+            case _:
+                raise ValueError(f"Unsupported input key: {in_type}")
+    return get_torch_dtype(in_type)
 
 
 def input_is_float(input_entry: dict) -> bool:
@@ -200,6 +217,13 @@ def apply_input_inits(tensor: torch.Tensor, inits: list[str]) -> torch.Tensor:
     return tensor
 
 
+@cache
+def _get_logger():
+    from ai_bench.utils.logger import setup_logger
+
+    return setup_logger()
+
+
 def get_inputs(
     variant: dict, inputs: dict, device: torch.device | None = None
 ) -> list[torch.Tensor]:
@@ -217,25 +241,27 @@ def get_inputs(
     for param in variant[VKey.PARAMS]:
         input_entry = inputs[param]
         shape = input_shape(input_entry, dims)
-        dtype = input_torch_dtype(input_entry)
+        dtype = input_torch_dtype(input_entry, variant)
         if variant_dtype is not None and dtype != variant_dtype:
-            warnings.warn(
+            logger = _get_logger()
+            logger.debug(
                 f"Input '{param}' dtype ({dtype}) differs from variant dtype "
-                f"({variant_dtype}). This may cause type mismatches.",
-                UserWarning,
-                stacklevel=2,
+                f"({variant_dtype}). This may cause type mismatches."
             )
 
-        if input_is_float(input_entry):
+        dtype_str = str(dtype)
+        if "float" in dtype_str:
             tensor = torch.randn(shape, dtype=dtype, device=device)
-        elif input_is_int(input_entry):
+        elif "int" in dtype_str:
             value_range = input_range(variant, input_entry)
             value_range = list(map(int, value_range))
             tensor = torch.randint(*value_range, shape, dtype=dtype, device=device)
-        elif input_is_bool(input_entry):
+        elif "bool" in dtype_str:
             tensor = torch.randint(0, 2, shape, dtype=torch.int64, device=device).bool()
         else:
-            raise TypeError("Only floating and integer types are supported now")
+            raise TypeError(
+                "Only floating, integer, and boolean types are supported now"
+            )
 
         if InKey.INITS in input_entry:
             tensor = apply_input_inits(tensor, input_entry[InKey.INITS])

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -111,7 +111,7 @@ def input_torch_dtype(input_entry: dict, variant: dict | None = None) -> torch.d
                     raise ValueError("Missing variant type for inheritance")
                 return dtype
             case _:
-                raise ValueError(f"Unsupported input key: {in_type}")
+                raise ValueError(f"Unimplemented input key: {in_type}")
     return get_torch_dtype(in_type)
 
 

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -108,7 +108,9 @@ def input_torch_dtype(input_entry: dict, variant: dict | None = None) -> torch.d
             case InInputKey.INHERIT:
                 dtype = get_variant_torch_dtype(variant) if variant else None
                 if dtype is None:
-                    raise ValueError("Missing variant type for inheritance")
+                    raise ValueError(
+                        "Input uses 'inherit' dtype but variant has no 'dtype' field"
+                    )
                 return dtype
             case _:
                 raise ValueError(f"Unimplemented input key: {in_type}")

--- a/problems/specs/KernelBench/level1/100_HingeLoss.yaml
+++ b/problems/specs/KernelBench/level1/100_HingeLoss.yaml
@@ -1,10 +1,10 @@
 inputs:
   predictions:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
   targets:
     shape: [BATCH_SIZE]
-    dtype: float16
+    dtype: inherit
     inits: [rademacher]
 
 inits: []

--- a/problems/specs/KernelBench/level1/10_3D_tensor_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/10_3D_tensor_matrix_multiplication.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [N, M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, L]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       N: 4
       M: 32
@@ -17,6 +18,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       N: 16
       M: 1024

--- a/problems/specs/KernelBench/level1/11_4D_tensor_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/11_4D_tensor_matrix_multiplication.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [B, I, J, L]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [L, K]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       B: 2
       I: 32
@@ -18,6 +19,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       B: 8
       I: 256

--- a/problems/specs/KernelBench/level1/12_Matmul_with_diagonal_matrices_.yaml
+++ b/problems/specs/KernelBench/level1/12_Matmul_with_diagonal_matrices_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [N]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [N, M]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 128
       N: 128
@@ -15,6 +16,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 4096
       N: 4096

--- a/problems/specs/KernelBench/level1/13_Matmul_for_symmetric_matrices.yaml
+++ b/problems/specs/KernelBench/level1/13_Matmul_for_symmetric_matrices.yaml
@@ -1,11 +1,11 @@
 inputs:
   A:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
     inits: [symmetric]
   B:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
     inits: [symmetric]
 
 inits: []

--- a/problems/specs/KernelBench/level1/14_Matmul_for_upper_triangular_matrices.yaml
+++ b/problems/specs/KernelBench/level1/14_Matmul_for_upper_triangular_matrices.yaml
@@ -1,11 +1,11 @@
 inputs:
   A:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
     inits: [triu]
   B:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
     inits: [triu]
 
 inits: []

--- a/problems/specs/KernelBench/level1/15_Matmul_for_lower_triangular_matrices.yaml
+++ b/problems/specs/KernelBench/level1/15_Matmul_for_lower_triangular_matrices.yaml
@@ -1,11 +1,11 @@
 inputs:
   A:
     shape: [M, M]
-    dtype: float16
+    dtype: inherit
     inits: [tril]
   B:
     shape: [M, M]
-    dtype: float16
+    dtype: inherit
     inits: [tril]
 
 inits: []

--- a/problems/specs/KernelBench/level1/16_Matmul_with_transposed_A.yaml
+++ b/problems/specs/KernelBench/level1/16_Matmul_with_transposed_A.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [K, M]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 128
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 1024
       N: 2048

--- a/problems/specs/KernelBench/level1/17_Matmul_with_transposed_B.yaml
+++ b/problems/specs/KernelBench/level1/17_Matmul_with_transposed_B.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [N, K]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 128
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 1024
       N: 2048

--- a/problems/specs/KernelBench/level1/18_Matmul_with_transposed_both.yaml
+++ b/problems/specs/KernelBench/level1/18_Matmul_with_transposed_both.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [K, M]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [N, K]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 128
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 1024
       N: 2048

--- a/problems/specs/KernelBench/level1/19_ReLU.yaml
+++ b/problems/specs/KernelBench/level1/19_ReLU.yaml
@@ -1,16 +1,18 @@
 inputs:
   X:
     shape: [BATCH, DIM]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       DIM: 512
 
 bench-cpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       DIM: 2048
@@ -19,6 +21,7 @@ bench-cpu:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       DIM: 16384

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -1,32 +1,37 @@
 inputs:
   A:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [N, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       N: 128
 
 bench-cpu:
   - params: [A, B]
+    dtype: float16
     dims:
       N: 256
     flop: "2*N*N*N"
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       N: 1024
     flop: "2*N*N*N"
   - params: [A, B]
+    dtype: float16
     dims:
       N: 2048
     flop: "2*N*N*N"
   - params: [A, B]
+    dtype: float16
     dims:
       N: 4096
     flop: "2*N*N*N"

--- a/problems/specs/KernelBench/level1/20_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level1/20_LeakyReLU.yaml
@@ -1,10 +1,11 @@
 inputs:
   X:
     shape: [BATCH, DIM]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 128
       DIM: 512
@@ -12,6 +13,7 @@ ci:
 
 bench-gpu:
   - params: [X]
+    dtype: float16
     dims:
       BATCH: 1024
       DIM: 16384

--- a/problems/specs/KernelBench/level1/21_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level1/21_Sigmoid.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/22_Tanh.yaml
+++ b/problems/specs/KernelBench/level1/22_Tanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/23_Softmax.yaml
+++ b/problems/specs/KernelBench/level1/23_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
+++ b/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/25_Swish.yaml
+++ b/problems/specs/KernelBench/level1/25_Swish.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/26_GELU_.yaml
+++ b/problems/specs/KernelBench/level1/26_GELU_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/27_SELU_.yaml
+++ b/problems/specs/KernelBench/level1/27_SELU_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
+++ b/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/29_Softplus.yaml
+++ b/problems/specs/KernelBench/level1/29_Softplus.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 128
@@ -15,6 +16,7 @@ ci:
 
 bench-cpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 128
       N: 256
@@ -24,6 +26,7 @@ bench-cpu:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 3072
       N: 3072

--- a/problems/specs/KernelBench/level1/30_Softsign.yaml
+++ b/problems/specs/KernelBench/level1/30_Softsign.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/31_ELU.yaml
+++ b/problems/specs/KernelBench/level1/31_ELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: ALPHA

--- a/problems/specs/KernelBench/level1/32_HardTanh.yaml
+++ b/problems/specs/KernelBench/level1/32_HardTanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/33_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level1/33_BatchNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: FEATURES

--- a/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
+++ b/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: FEATURES

--- a/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
+++ b/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: FEATURES

--- a/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
+++ b/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: FEATURES

--- a/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
+++ b/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/38_L1Norm_.yaml
+++ b/problems/specs/KernelBench/level1/38_L1Norm_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/39_L2Norm_.yaml
+++ b/problems/specs/KernelBench/level1/39_L2Norm_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/3_Batched_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/3_Batched_matrix_multiplication.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [BATCH, M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [BATCH, K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       BATCH: 2
       M: 64
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       BATCH: 128
       M: 512

--- a/problems/specs/KernelBench/level1/40_LayerNorm.yaml
+++ b/problems/specs/KernelBench/level1/40_LayerNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NORMALIZED_SHAPE

--- a/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, SEQUENCE_LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: KERNEL_SIZE

--- a/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: KERNEL_SIZE

--- a/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
+++ b/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, FEATURES, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: FEATURES

--- a/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, INPUT_LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: KERNEL_SIZE

--- a/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: KERNEL_SIZE

--- a/problems/specs/KernelBench/level1/46_Average_Pooling_3D.yaml
+++ b/problems/specs/KernelBench/level1/46_Average_Pooling_3D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: KERNEL_SIZE

--- a/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: REDUCE_DIM

--- a/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: REDUCE_DIM

--- a/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: REDUCE_DIM

--- a/problems/specs/KernelBench/level1/4_Matrix_vector_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/4_Matrix_vector_multiplication_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 1
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 2048
       N: 1

--- a/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: ARGMAX_DIM

--- a/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: ARGMIN_DIM

--- a/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM1, DIM2]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: REDUCE_DIM

--- a/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, WIDTH, HEIGHT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH_IN, HEIGHT_IN, WIDTH_IN]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH, DEPTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/5_Matrix_scalar_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/5_Matrix_scalar_multiplication.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, N]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [UNIT]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 64
       N: 32
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 16384
       N: 4096

--- a/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, WIDTH, HEIGHT, DEPTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
+++ b/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
+++ b/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, WIDTH, HEIGHT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/6_Matmul_with_large_K_dimension_.yaml
+++ b/problems/specs/KernelBench/level1/6_Matmul_with_large_K_dimension_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 8
       N: 16
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 256
       N: 256

--- a/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
+++ b/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
+++ b/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
+++ b/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
+++ b/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
+++ b/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
+++ b/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, LENGTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/7_Matmul_with_small_K_dimension_.yaml
+++ b/problems/specs/KernelBench/level1/7_Matmul_with_small_K_dimension_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 256
       N: 256
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 8192
       N: 8192

--- a/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
+++ b/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
+++ b/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT_IN, WIDTH_IN]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
+++ b/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
+++ b/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
+++ b/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/89_cumsum.yaml
+++ b/problems/specs/KernelBench/level1/89_cumsum.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: SCAN_DIM

--- a/problems/specs/KernelBench/level1/8_Matmul_with_irregular_shapes_.yaml
+++ b/problems/specs/KernelBench/level1/8_Matmul_with_irregular_shapes_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, K]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [K, N]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 60
       N: 37
@@ -16,6 +17,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 8205
       N: 5921

--- a/problems/specs/KernelBench/level1/90_cumprod.yaml
+++ b/problems/specs/KernelBench/level1/90_cumprod.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: SCAN_DIM

--- a/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
+++ b/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: SCAN_DIM

--- a/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
+++ b/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: SCAN_DIM

--- a/problems/specs/KernelBench/level1/93_masked_cumsum.yaml
+++ b/problems/specs/KernelBench/level1/93_masked_cumsum.yaml
@@ -1,7 +1,7 @@
 inputs:
   x:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
   mask:
     shape: [BATCH_SIZE, INPUT_DIM]
     dtype: bool

--- a/problems/specs/KernelBench/level1/94_MSELoss.yaml
+++ b/problems/specs/KernelBench/level1/94_MSELoss.yaml
@@ -1,11 +1,11 @@
 inputs:
   predictions:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
     inits: [scale]
   targets:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
+++ b/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
@@ -1,7 +1,7 @@
 inputs:
   predictions:
     shape: [BATCH_SIZE, NUM_CLASSES]
-    dtype: float16
+    dtype: inherit
   targets:
     shape: [BATCH_SIZE]
     dtype: int64

--- a/problems/specs/KernelBench/level1/96_HuberLoss.yaml
+++ b/problems/specs/KernelBench/level1/96_HuberLoss.yaml
@@ -1,11 +1,11 @@
 inputs:
   predictions:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
     inits: [scale]
   targets:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
+++ b/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
@@ -4,10 +4,10 @@ inputs:
     dtype: float16
   K:
     shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
-    dtype: float16
+    dtype: inherit
   V:
     shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
+++ b/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
@@ -1,7 +1,7 @@
 inputs:
   Q:
     shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
-    dtype: float16
+    dtype: inherit
   K:
     shape: [BATCH_SIZE, NUM_HEADS, SEQUENCE_LENGTH, EMBEDDING_DIMENSION]
     dtype: inherit

--- a/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
+++ b/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
@@ -1,11 +1,11 @@
 inputs:
   predictions:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
     inits: [scale, softmax]
   targets:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
     inits: [softmax]
 
 inits: []

--- a/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
+++ b/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
@@ -5,10 +5,10 @@ inputs:
     inits: [scale]
   positive:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
   negative:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: MARGIN

--- a/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
+++ b/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
@@ -1,7 +1,7 @@
 inputs:
   anchor:
     shape: [BATCH_SIZE, INPUT_DIM]
-    dtype: float16
+    dtype: inherit
     inits: [scale]
   positive:
     shape: [BATCH_SIZE, INPUT_DIM]

--- a/problems/specs/KernelBench/level1/9_Tall_skinny_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/9_Tall_skinny_matrix_multiplication_.yaml
@@ -1,13 +1,14 @@
 inputs:
   A:
     shape: [M, N]
-    dtype: float16
+    dtype: inherit
   B:
     shape: [N, M]
-    dtype: float16
+    dtype: inherit
 
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 256
       N: 16
@@ -15,6 +16,7 @@ ci:
 
 bench-gpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 8192
       N: 32

--- a/problems/specs/KernelBench/level2/100_ConvTranspose3d_Clamp_Min_Divide.yaml
+++ b/problems/specs/KernelBench/level2/100_ConvTranspose3d_Clamp_Min_Divide.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/10_ConvTranspose2d_MaxPool_Hardtanh_Mean_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/10_ConvTranspose2d_MaxPool_Hardtanh_Mean_Tanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/13_ConvTranspose3d_Mean_Add_Softmax_Tanh_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/13_ConvTranspose3d_Mean_Add_Softmax_Tanh_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_SIZE

--- a/problems/specs/KernelBench/level2/15_ConvTranspose3d_BatchNorm_Subtract.yaml
+++ b/problems/specs/KernelBench/level2/15_ConvTranspose3d_BatchNorm_Subtract.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/17_Conv2d_InstanceNorm_Divide.yaml
+++ b/problems/specs/KernelBench/level2/17_Conv2d_InstanceNorm_Divide.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/19_ConvTranspose2d_GELU_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/19_ConvTranspose2d_GELU_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/21_Conv2d_Add_Scale_Sigmoid_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/21_Conv2d_Add_Scale_Sigmoid_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.yaml
+++ b/problems/specs/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/23_Conv3d_GroupNorm_Mean.yaml
+++ b/problems/specs/KernelBench/level2/23_Conv3d_GroupNorm_Mean.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/24_Conv3d_Min_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/24_Conv3d_Min_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/25_Conv2d_Min_Tanh_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/25_Conv2d_Min_Tanh_Tanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/26_ConvTranspose3d_Add_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/26_ConvTranspose3d_Add_HardSwish.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
   ADD_INPUT:
     shape: [BATCH_SIZE, OUT_CHANNELS, D_OUT, H_OUT, W_OUT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/27_Conv3d_HardSwish_GroupNorm_Mean.yaml
+++ b/problems/specs/KernelBench/level2/27_Conv3d_HardSwish_GroupNorm_Mean.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
   Y:
     shape: [BATCH_SIZE, OUT_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/29_Matmul_Mish_Mish.yaml
+++ b/problems/specs/KernelBench/level2/29_Matmul_Mish_Mish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/2_ConvTranspose2d_BiasAdd_Clamp_Scaling_Clamp_Divide.yaml
+++ b/problems/specs/KernelBench/level2/2_ConvTranspose2d_BiasAdd_Clamp_Scaling_Clamp_Divide.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.yaml
+++ b/problems/specs/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/31_Conv2d_Min_Add_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/31_Conv2d_Min_Add_Multiply.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/32_Conv2d_Scaling_Min.yaml
+++ b/problems/specs/KernelBench/level2/32_Conv2d_Scaling_Min.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/33_Gemm_Scale_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/33_Gemm_Scale_BatchNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.yaml
+++ b/problems/specs/KernelBench/level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/36_ConvTranspose2d_Min_Sum_GELU_Add.yaml
+++ b/problems/specs/KernelBench/level2/36_ConvTranspose2d_Min_Sum_GELU_Add.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/38_ConvTranspose3d_AvgPool_Clamp_Softmax_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/38_ConvTranspose3d_AvgPool_Clamp_Softmax_Multiply.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/39_Gemm_Scale_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/39_Gemm_Scale_BatchNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/3_ConvTranspose3d_Sum_LayerNorm_AvgPool_GELU.yaml
+++ b/problems/specs/KernelBench/level2/3_ConvTranspose3d_Sum_LayerNorm_AvgPool_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/40_Matmul_Scaling_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/40_Matmul_Scaling_ResidualAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/43_Conv3d_Max_LogSumExp_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/43_Conv3d_Max_LogSumExp_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.yaml
+++ b/problems/specs/KernelBench/level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.yaml
+++ b/problems/specs/KernelBench/level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/47_Conv3d_Mish_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/47_Conv3d_Mish_Tanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/48_Conv3d_Scaling_Tanh_Multiply_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/48_Conv3d_Scaling_Tanh_Multiply_Sigmoid.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/49_ConvTranspose3d_Softmax_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/49_ConvTranspose3d_Softmax_Sigmoid.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/4_Conv2d_Mish_Mish.yaml
+++ b/problems/specs/KernelBench/level2/4_Conv2d_Mish_Mish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/50_ConvTranspose3d_Scaling_AvgPool_BiasAdd_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/50_ConvTranspose3d_Scaling_AvgPool_BiasAdd_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/52_Conv2d_Activation_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/52_Conv2d_Activation_BatchNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/53_Gemm_Scaling_Hardtanh_GELU.yaml
+++ b/problems/specs/KernelBench/level2/53_Gemm_Scaling_Hardtanh_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/54_Conv2d_Multiply_LeakyReLU_GELU.yaml
+++ b/problems/specs/KernelBench/level2/54_Conv2d_Multiply_LeakyReLU_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.yaml
+++ b/problems/specs/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/56_Matmul_Sigmoid_Sum.yaml
+++ b/problems/specs/KernelBench/level2/56_Matmul_Sigmoid_Sum.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/57_Conv2d_ReLU_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/57_Conv2d_ReLU_HardSwish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/58_ConvTranspose3d_LogSumExp_HardSwish_Subtract_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/58_ConvTranspose3d_LogSumExp_HardSwish_Subtract_Clamp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/59_Matmul_Swish_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/59_Matmul_Swish_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/5_ConvTranspose2d_Subtract_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/5_ConvTranspose2d_Subtract_Tanh.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/61_ConvTranspose3d_ReLU_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/61_ConvTranspose3d_ReLU_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, D, H, W]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.yaml
+++ b/problems/specs/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/63_Gemm_ReLU_Divide.yaml
+++ b/problems/specs/KernelBench/level2/63_Gemm_ReLU_Divide.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.yaml
+++ b/problems/specs/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/65_Conv2d_AvgPool_Sigmoid_Sum.yaml
+++ b/problems/specs/KernelBench/level2/65_Conv2d_AvgPool_Sigmoid_Sum.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/66_Matmul_Dropout_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/66_Matmul_Dropout_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/67_Conv2d_GELU_GlobalAvgPool.yaml
+++ b/problems/specs/KernelBench/level2/67_Conv2d_GELU_GlobalAvgPool.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/68_Matmul_Min_Subtract.yaml
+++ b/problems/specs/KernelBench/level2/68_Matmul_Min_Subtract.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/69_Conv2d_HardSwish_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/69_Conv2d_HardSwish_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/6_Conv3d_Softmax_MaxPool_MaxPool.yaml
+++ b/problems/specs/KernelBench/level2/6_Conv3d_Softmax_MaxPool_MaxPool.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/70_Gemm_Sigmoid_Scaling_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/70_Gemm_Sigmoid_Scaling_ResidualAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/71_Conv2d_Divide_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/71_Conv2d_Divide_LeakyReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/72_ConvTranspose3d_BatchNorm_AvgPool_AvgPool.yaml
+++ b/problems/specs/KernelBench/level2/72_ConvTranspose3d_BatchNorm_AvgPool_AvgPool.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/73_Conv2d_BatchNorm_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/73_Conv2d_BatchNorm_Scaling.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.yaml
+++ b/problems/specs/KernelBench/level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/76_Gemm_Add_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/76_Gemm_Add_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.yaml
+++ b/problems/specs/KernelBench/level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/78_ConvTranspose3d_Max_Max_Sum.yaml
+++ b/problems/specs/KernelBench/level2/78_ConvTranspose3d_Max_Max_Sum.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/79_Conv3d_Multiply_InstanceNorm_Clamp_Multiply_Max.yaml
+++ b/problems/specs/KernelBench/level2/79_Conv3d_Multiply_InstanceNorm_Clamp_Multiply_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/7_Conv3d_ReLU_LeakyReLU_GELU_Sigmoid_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/7_Conv3d_ReLU_LeakyReLU_GELU_Sigmoid_BiasAdd.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/80_Gemm_Max_Subtract_GELU.yaml
+++ b/problems/specs/KernelBench/level2/80_Gemm_Max_Subtract_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/82_Conv2d_Tanh_Scaling_BiasAdd_Max.yaml
+++ b/problems/specs/KernelBench/level2/82_Conv2d_Tanh_Scaling_BiasAdd_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/83_Conv3d_GroupNorm_Min_Clamp_Dropout.yaml
+++ b/problems/specs/KernelBench/level2/83_Conv3d_GroupNorm_Min_Clamp_Dropout.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/85_Conv2d_GroupNorm_Scale_MaxPool_Clamp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_CH, H, W]
-    dtype: float32
+    dtype: inherit
 
 inits:
   - dim: IN_CH

--- a/problems/specs/KernelBench/level2/86_Matmul_Divide_GELU.yaml
+++ b/problems/specs/KernelBench/level2/86_Matmul_Divide_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level2/87_Conv2d_Subtract_Subtract_Mish.yaml
+++ b/problems/specs/KernelBench/level2/87_Conv2d_Subtract_Subtract_Mish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.yaml
+++ b/problems/specs/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/89_ConvTranspose3d_MaxPool_Softmax_Subtract_Swish_Max.yaml
+++ b/problems/specs/KernelBench/level2/89_ConvTranspose3d_MaxPool_Softmax_Subtract_Swish_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.yaml
+++ b/problems/specs/KernelBench/level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/90_Conv3d_LeakyReLU_Sum_Clamp_GELU.yaml
+++ b/problems/specs/KernelBench/level2/90_Conv3d_LeakyReLU_Sum_Clamp_GELU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/91_ConvTranspose2d_Softmax_BiasAdd_Scaling_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/91_ConvTranspose2d_Softmax_BiasAdd_Scaling_Sigmoid.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_FEATURES]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEATURES

--- a/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
+++ b/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
@@ -4,7 +4,7 @@ description: Matrix multiplication with bias, add value, followed by Swish, Tanh
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/96_ConvTranspose3d_Multiply_Max_GlobalAvgPool_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/96_ConvTranspose3d_Multiply_Max_GlobalAvgPool_Clamp.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, DEPTH, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
+++ b/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
+++ b/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_FEAT]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_FEAT

--- a/problems/specs/KernelBench/level3/10_ResNet101.yaml
+++ b/problems/specs/KernelBench/level3/10_ResNet101.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: LAYERS

--- a/problems/specs/KernelBench/level3/11_VGG16.yaml
+++ b/problems/specs/KernelBench/level3/11_VGG16.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/12_VGG19.yaml
+++ b/problems/specs/KernelBench/level3/12_VGG19.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
+++ b/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, NUM_INPUT_FEATURES, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_INPUT_FEATURES

--- a/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
+++ b/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, NUM_INPUT_FEATURES, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_LAYERS

--- a/problems/specs/KernelBench/level3/15_DenseNet121.yaml
+++ b/problems/specs/KernelBench/level3/15_DenseNet121.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: GROWTH_RATE

--- a/problems/specs/KernelBench/level3/16_DenseNet201.yaml
+++ b/problems/specs/KernelBench/level3/16_DenseNet201.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: GROWTH_RATE

--- a/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
+++ b/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
+++ b/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
+++ b/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/1_MLP.yaml
+++ b/problems/specs/KernelBench/level3/1_MLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_SIZE

--- a/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
+++ b/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
+++ b/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
+++ b/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
+++ b/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
+++ b/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
+++ b/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
+++ b/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/27_RegNet.yaml
+++ b/problems/specs/KernelBench/level3/27_RegNet.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_CHANNELS

--- a/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IMAGE_SIZE

--- a/problems/specs/KernelBench/level3/29_SwinMLP.yaml
+++ b/problems/specs/KernelBench/level3/29_SwinMLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
+++ b/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_SIZE

--- a/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
+++ b/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits: []
 

--- a/problems/specs/KernelBench/level3/31_VisionAttention.yaml
+++ b/problems/specs/KernelBench/level3/31_VisionAttention.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, EMBED_DIM, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: EMBED_DIM

--- a/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, IMAGE_SIZE, IMAGE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
+++ b/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   INITIAL_HIDDEN:
     shape: [BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
+++ b/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/35_LSTM.yaml
+++ b/problems/specs/KernelBench/level3/35_LSTM.yaml
@@ -4,10 +4,10 @@ inputs:
     dtype: float16
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
   C0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/35_LSTM.yaml
+++ b/problems/specs/KernelBench/level3/35_LSTM.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
     dtype: inherit

--- a/problems/specs/KernelBench/level3/36_LSTMHn.yaml
+++ b/problems/specs/KernelBench/level3/36_LSTMHn.yaml
@@ -4,10 +4,10 @@ inputs:
     dtype: float16
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
   C0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/36_LSTMHn.yaml
+++ b/problems/specs/KernelBench/level3/36_LSTMHn.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
     dtype: inherit

--- a/problems/specs/KernelBench/level3/37_LSTMCn.yaml
+++ b/problems/specs/KernelBench/level3/37_LSTMCn.yaml
@@ -4,10 +4,10 @@ inputs:
     dtype: float16
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
   C0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/37_LSTMCn.yaml
+++ b/problems/specs/KernelBench/level3/37_LSTMCn.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
     dtype: inherit

--- a/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
@@ -4,10 +4,10 @@ inputs:
     dtype: float16
   H0:
     shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
   C0:
     shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
     dtype: inherit

--- a/problems/specs/KernelBench/level3/39_GRU.yaml
+++ b/problems/specs/KernelBench/level3/39_GRU.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
+++ b/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_SIZE

--- a/problems/specs/KernelBench/level3/40_GRUHidden.yaml
+++ b/problems/specs/KernelBench/level3/40_GRUHidden.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
+++ b/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
@@ -1,10 +1,10 @@
 inputs:
   X:
     shape: [SEQUENCE_LENGTH, BATCH_SIZE, INPUT_SIZE]
-    dtype: float16
+    dtype: inherit
   H0:
     shape: [NUM_LAYERS_BIDIRECTIONAL, BATCH_SIZE, HIDDEN_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: INPUT_SIZE

--- a/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
+++ b/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, SEQ_LEN, N_EMBD]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: N_EMBD

--- a/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
+++ b/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, N_EMBD]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: N_EMBD

--- a/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
+++ b/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, NUM_FEATURES, FEATURE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: CLUSTER_SIZE

--- a/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, NUM_FEATURES, FEATURE_SIZE]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: CLUSTER_SIZE

--- a/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
+++ b/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQ_LENGTH, N_HEADS, D_HEAD]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: BATCH_SIZE

--- a/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
+++ b/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQ_LENGTH, N_HEADS, D_HEAD]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: BATCH_SIZE

--- a/problems/specs/KernelBench/level3/4_LeNet5.yaml
+++ b/problems/specs/KernelBench/level3/4_LeNet5.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_1, IN_2, IN_3]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
+++ b/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, SEQUENCE_LENGTH, N_EMBD]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: N_EMBD

--- a/problems/specs/KernelBench/level3/5_AlexNet.yaml
+++ b/problems/specs/KernelBench/level3/5_AlexNet.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_1, IN_2, IN_3]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
+++ b/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS
@@ -33,6 +33,7 @@ ci:
 #
 # bench-gpu:
 #   - params: [X]
+#     dtype: float16
 #     dims:
 #       IN_CHANNELS: 480
 #       OUT_1x1: 192

--- a/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
+++ b/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, INPUT_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
+++ b/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [BATCH_SIZE, IN_CHANNELS, HEIGHT, WIDTH]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: IN_CHANNELS

--- a/problems/specs/KernelBench/level3/9_ResNet18.yaml
+++ b/problems/specs/KernelBench/level3/9_ResNet18.yaml
@@ -1,7 +1,7 @@
 inputs:
   X:
     shape: [IN_1, IN_2, IN_3, IN_4]
-    dtype: float16
+    dtype: inherit
 
 inits:
   - dim: NUM_CLASSES

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -374,6 +374,7 @@ inputs:
     dtype: float32
 ci:
   - params: [X]
+    dtype: float16
     dims:
       N: 8
 """
@@ -413,6 +414,7 @@ inputs:
     dtype: float32
 ci:
   - params: [A]
+    dtype: float16
     dims:
       N: 4
 """
@@ -514,6 +516,7 @@ inits:
   - dim: H
 ci:
   - params: [X]
+    dtype: float16
     dims:
       B: 2
       H: 16
@@ -557,6 +560,7 @@ inits:
   - dim: H
 ci:
   - params: [X]
+    dtype: float16
     dims:
       B: 2
       H: 16
@@ -710,12 +714,14 @@ inputs:
     dtype: float32
 ci:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 8
       K: 8
       N: 8
 bench-cpu:
   - params: [A, B]
+    dtype: float16
     dims:
       M: 32
       K: 32

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -374,7 +374,6 @@ inputs:
     dtype: float32
 ci:
   - params: [X]
-    dtype: float16
     dims:
       N: 8
 """
@@ -414,7 +413,6 @@ inputs:
     dtype: float32
 ci:
   - params: [A]
-    dtype: float16
     dims:
       N: 4
 """
@@ -516,7 +514,6 @@ inits:
   - dim: H
 ci:
   - params: [X]
-    dtype: float16
     dims:
       B: 2
       H: 16
@@ -560,7 +557,6 @@ inits:
   - dim: H
 ci:
   - params: [X]
-    dtype: float16
     dims:
       B: 2
       H: 16
@@ -714,14 +710,12 @@ inputs:
     dtype: float32
 ci:
   - params: [A, B]
-    dtype: float16
     dims:
       M: 8
       K: 8
       N: 8
 bench-cpu:
   - params: [A, B]
-    dtype: float16
     dims:
       M: 32
       K: 32

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -98,6 +98,7 @@ class Model(torch.nn.Module):
 def test_env_var_log_levels(monkeypatch, caplog):
     info_txt = "info msg"
     debug_txt = "debug msg"
+    logger_name = "log_test"
 
     def print_log(logger):
         caplog.clear()
@@ -106,19 +107,19 @@ def test_env_var_log_levels(monkeypatch, caplog):
         return caplog.text
 
     monkeypatch.delenv("AIBENCH_LOG", raising=False)
-    logger = setup_logger(level=logging.INFO)
+    logger = setup_logger(logger_name, level=logging.INFO)
     out = print_log(logger)
     assert info_txt in out
     assert debug_txt not in out
 
     monkeypatch.setenv("AIBENCH_LOG", "INFO")
-    logger = setup_logger()
+    logger = setup_logger(logger_name)
     out = print_log(logger)
     assert info_txt in out
     assert debug_txt not in out
 
     monkeypatch.setenv("AIBENCH_LOG", "DEBUG")
-    logger = setup_logger()
+    logger = setup_logger(logger_name)
     out = print_log(logger)
     assert info_txt in out
     assert debug_txt in out

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,7 +45,6 @@ inputs:
     dtype: float32
 bench-cpu:
   - params: [X]
-    dtype: float16
     dims:
       N: 4
     flop: 8*N

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -45,6 +45,7 @@ inputs:
     dtype: float32
 bench-cpu:
   - params: [X]
+    dtype: float16
     dims:
       N: 4
     flop: 8*N

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,5 +1,6 @@
 """Tests for dtype mismatch warning between input and variant specs."""
 
+import logging
 import warnings
 
 import pytest
@@ -8,8 +9,77 @@ import torch
 from ai_bench.harness import core as ai_hc
 
 
-class TestDtypeMismatchWarning:
-    """Tests for dtype mismatch warning in get_inputs."""
+class TestInputDataTypes:
+    def test_input_data_types(self):
+        """Test inputs with various data types."""
+        float_param = "T_FLOAT"
+        int_param = "T_INT"
+        bool_param = "T_BOOL"
+        inherit_param = "T_INHERIT"
+
+        variant = {
+            ai_hc.VKey.PARAMS: [float_param, int_param, bool_param, inherit_param],
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.DIMS: {"BATCH": 2, "IN_FEAT": 8},
+        }
+        inputs = {
+            float_param: {
+                ai_hc.InKey.SHAPE: ["BATCH", "IN_FEAT"],
+                ai_hc.InKey.TYPE: "bfloat16",
+            },
+            int_param: {
+                ai_hc.InKey.SHAPE: ["BATCH"],
+                ai_hc.InKey.TYPE: "int64",
+                ai_hc.InKey.RANGE: [0, "IN_FEAT"],
+            },
+            bool_param: {
+                ai_hc.InKey.SHAPE: ["IN_FEAT"],
+                ai_hc.InKey.TYPE: "bool",
+            },
+            inherit_param: {
+                ai_hc.InKey.SHAPE: ["IN_FEAT"],
+                ai_hc.InKey.TYPE: ai_hc.InInputKey.INHERIT,
+            },
+        }
+
+        input_float = inputs[float_param]
+        assert ai_hc.input_is_float(input_float)
+        assert not ai_hc.input_is_int(input_float)
+        assert not ai_hc.input_is_bool(input_float)
+
+        input_int = inputs[int_param]
+        assert not ai_hc.input_is_float(input_int)
+        assert ai_hc.input_is_int(input_int)
+        assert not ai_hc.input_is_bool(input_int)
+
+        input_bool = inputs[bool_param]
+        assert not ai_hc.input_is_float(input_bool)
+        assert not ai_hc.input_is_int(input_bool)
+        assert ai_hc.input_is_bool(input_bool)
+
+        input_inherit = inputs[inherit_param]
+        assert not ai_hc.input_is_float(input_inherit)
+        assert not ai_hc.input_is_int(input_inherit)
+        assert not ai_hc.input_is_bool(input_inherit)
+        with pytest.raises(Exception) as e:
+            ai_hc.input_torch_dtype(input_inherit)
+        assert "Missing variant" in str(e)
+        inherit_dtype = ai_hc.input_torch_dtype(input_inherit, variant)
+        assert inherit_dtype == torch.float32
+
+        int_range = ai_hc.input_range(variant, input_int)
+        assert int_range == [0, 8]
+
+        inputs = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert len(inputs) == 4
+        assert inputs[0].dtype == torch.bfloat16
+        assert inputs[1].dtype == torch.int64
+        assert inputs[2].dtype == torch.bool
+        assert inputs[3].dtype == torch.float32
+
+
+class TestIntegerInputCreation:
+    """Tests for integer input creation."""
 
     def test_input_int_ranges(self):
         """Test integer inputs with various value ranges."""
@@ -53,57 +123,30 @@ class TestDtypeMismatchWarning:
         assert inputs[1].dtype == torch.int32
         assert inputs[2].dtype == torch.int16
 
-    def test_input_data_types(self):
-        """Test inputs with various data types."""
-        float_param = "T_FLOAT"
-        int_param = "T_INT"
-        bool_param = "T_BOOL"
-
+    def test_integer_inheritance(self):
+        """Test integer type inherited from the variant."""
         variant = {
-            ai_hc.VKey.PARAMS: [float_param, int_param, bool_param],
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.TYPE: "int16",
             ai_hc.VKey.DIMS: {"BATCH": 2, "IN_FEAT": 8},
         }
         inputs = {
-            float_param: {
-                ai_hc.InKey.SHAPE: ["BATCH", "IN_FEAT"],
-                ai_hc.InKey.TYPE: "bfloat16",
-            },
-            int_param: {
+            "X": {
                 ai_hc.InKey.SHAPE: ["BATCH"],
-                ai_hc.InKey.TYPE: "int64",
-                ai_hc.InKey.RANGE: [0, "IN_FEAT"],
-            },
-            bool_param: {
-                ai_hc.InKey.SHAPE: ["IN_FEAT"],
-                ai_hc.InKey.TYPE: "bool",
+                ai_hc.InKey.TYPE: ai_hc.InInputKey.INHERIT,
+                ai_hc.InKey.RANGE: [1, 5],
             },
         }
 
-        input_float = inputs[float_param]
-        assert ai_hc.input_is_float(input_float)
-        assert not ai_hc.input_is_int(input_float)
-        assert not ai_hc.input_is_bool(input_float)
-
-        input_int = inputs[int_param]
-        assert not ai_hc.input_is_float(input_int)
-        assert ai_hc.input_is_int(input_int)
-        assert not ai_hc.input_is_bool(input_int)
-
-        input_bool = inputs[bool_param]
-        assert not ai_hc.input_is_float(input_bool)
-        assert not ai_hc.input_is_int(input_bool)
-        assert ai_hc.input_is_bool(input_bool)
-
-        int_range = ai_hc.input_range(variant, input_int)
-        assert int_range == [0, 8]
-
         inputs = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
-        assert len(inputs) == 3
-        assert inputs[0].dtype == torch.bfloat16
-        assert inputs[1].dtype == torch.int64
-        assert inputs[2].dtype == torch.bool
+        assert len(inputs) == 1
+        assert inputs[0].dtype == torch.int16
 
-    def test_warns_on_dtype_mismatch(self):
+
+class TestDtypeMismatchWarning:
+    """Tests for dtype mismatch warning in get_inputs."""
+
+    def test_warns_on_dtype_mismatch(self, caplog):
         """Test that warning is raised when input dtype differs from variant dtype."""
         variant = {
             ai_hc.VKey.PARAMS: ["X"],
@@ -117,15 +160,11 @@ class TestDtypeMismatchWarning:
             },
         }
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.DEBUG):
             tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
-
-            assert len(w) == 1
-            assert issubclass(w[0].category, UserWarning)
-            assert "dtype" in str(w[0].message).lower()
-            assert "float16" in str(w[0].message)
-            assert "bfloat16" in str(w[0].message)
+        assert "dtype" in str(caplog.text).lower()
+        assert "float16" in str(caplog.text)
+        assert "bfloat16" in str(caplog.text)
 
         # Tensor should still be created with input dtype.
         assert tensors[0].dtype == torch.float16

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,8 +1,5 @@
 """Tests for dtype mismatch warning between input and variant specs."""
 
-import logging
-import warnings
-
 import pytest
 import torch
 
@@ -63,7 +60,7 @@ class TestInputDataTypes:
         assert not ai_hc.input_is_bool(input_inherit)
         with pytest.raises(Exception) as e:
             ai_hc.input_torch_dtype(input_inherit)
-        assert "Missing variant" in str(e)
+        assert "Input uses 'inherit' dtype but variant has no 'dtype' field" in str(e)
         inherit_dtype = ai_hc.input_torch_dtype(input_inherit, variant)
         assert inherit_dtype == torch.float32
 
@@ -160,16 +157,16 @@ class TestDtypeMismatchWarning:
             },
         }
 
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level("DEBUG", logger="ai_bench"):
             tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
-        assert "dtype" in str(caplog.text).lower()
-        assert "float16" in str(caplog.text)
-        assert "bfloat16" in str(caplog.text)
+            assert "dtype" in caplog.text
+            assert "float16" in caplog.text
+            assert "bfloat16" in caplog.text
 
         # Tensor should still be created with input dtype.
         assert tensors[0].dtype == torch.float16
 
-    def test_no_warning_when_dtypes_match(self):
+    def test_no_warning_when_dtypes_match(self, caplog):
         """Test that no warning is raised when input and variant dtypes match."""
         variant = {
             ai_hc.VKey.PARAMS: ["X"],
@@ -183,11 +180,9 @@ class TestDtypeMismatchWarning:
             },
         }
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with caplog.at_level("DEBUG", logger="ai_bench"):
             ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
-
-            assert len(w) == 0
+            assert "dtype" not in caplog.text
 
 
 class TestInputInitializations:


### PR DESCRIPTION
Adds a new input entry type key 'inherit' that sets input's data type to the type of the currently run variant.
Slightly refactors specs test cases.

This allows creation of problem variants using different data types. When the inheritance is used and a variant does not specify a type, an exception is raised.