### PR TITLE
[problems] Switch CI variants to float32

### DIFF
--- a/problems/specs/KernelBench/level1/100_HingeLoss.yaml
+++ b/problems/specs/KernelBench/level1/100_HingeLoss.yaml
@@ -11,7 +11,7 @@ inits: []
 
 ci:
   - params: [predictions, targets]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/10_3D_tensor_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/10_3D_tensor_matrix_multiplication.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       N: 4
       M: 32

--- a/problems/specs/KernelBench/level1/11_4D_tensor_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/11_4D_tensor_matrix_multiplication.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       B: 2
       I: 32

--- a/problems/specs/KernelBench/level1/12_Matmul_with_diagonal_matrices_.yaml
+++ b/problems/specs/KernelBench/level1/12_Matmul_with_diagonal_matrices_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 128
       N: 128

--- a/problems/specs/KernelBench/level1/13_Matmul_for_symmetric_matrices.yaml
+++ b/problems/specs/KernelBench/level1/13_Matmul_for_symmetric_matrices.yaml
@@ -12,6 +12,6 @@ inits: []
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       N: 64

--- a/problems/specs/KernelBench/level1/14_Matmul_for_upper_triangular_matrices.yaml
+++ b/problems/specs/KernelBench/level1/14_Matmul_for_upper_triangular_matrices.yaml
@@ -12,6 +12,6 @@ inits: []
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       N: 64

--- a/problems/specs/KernelBench/level1/15_Matmul_for_lower_triangular_matrices.yaml
+++ b/problems/specs/KernelBench/level1/15_Matmul_for_lower_triangular_matrices.yaml
@@ -12,6 +12,6 @@ inits: []
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64

--- a/problems/specs/KernelBench/level1/16_Matmul_with_transposed_A.yaml
+++ b/problems/specs/KernelBench/level1/16_Matmul_with_transposed_A.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 128

--- a/problems/specs/KernelBench/level1/17_Matmul_with_transposed_B.yaml
+++ b/problems/specs/KernelBench/level1/17_Matmul_with_transposed_B.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 128

--- a/problems/specs/KernelBench/level1/18_Matmul_with_transposed_both.yaml
+++ b/problems/specs/KernelBench/level1/18_Matmul_with_transposed_both.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 128

--- a/problems/specs/KernelBench/level1/19_ReLU.yaml
+++ b/problems/specs/KernelBench/level1/19_ReLU.yaml
@@ -5,7 +5,7 @@ inputs:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       N: 128
 

--- a/problems/specs/KernelBench/level1/20_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level1/20_LeakyReLU.yaml
@@ -5,7 +5,7 @@ inputs:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/21_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level1/21_Sigmoid.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/22_Tanh.yaml
+++ b/problems/specs/KernelBench/level1/22_Tanh.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/23_Softmax.yaml
+++ b/problems/specs/KernelBench/level1/23_Softmax.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
+++ b/problems/specs/KernelBench/level1/24_LogSoftmax.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/25_Swish.yaml
+++ b/problems/specs/KernelBench/level1/25_Swish.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/26_GELU_.yaml
+++ b/problems/specs/KernelBench/level1/26_GELU_.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/27_SELU_.yaml
+++ b/problems/specs/KernelBench/level1/27_SELU_.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
+++ b/problems/specs/KernelBench/level1/28_HardSigmoid.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/29_Softplus.yaml
+++ b/problems/specs/KernelBench/level1/29_Softplus.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 128

--- a/problems/specs/KernelBench/level1/30_Softsign.yaml
+++ b/problems/specs/KernelBench/level1/30_Softsign.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/31_ELU.yaml
+++ b/problems/specs/KernelBench/level1/31_ELU.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/32_HardTanh.yaml
+++ b/problems/specs/KernelBench/level1/32_HardTanh.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/33_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level1/33_BatchNorm.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
+++ b/problems/specs/KernelBench/level1/34_InstanceNorm.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
+++ b/problems/specs/KernelBench/level1/35_GroupNorm_.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 8

--- a/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
+++ b/problems/specs/KernelBench/level1/36_RMSNorm_.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
+++ b/problems/specs/KernelBench/level1/37_FrobeniusNorm_.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/38_L1Norm_.yaml
+++ b/problems/specs/KernelBench/level1/38_L1Norm_.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/39_L2Norm_.yaml
+++ b/problems/specs/KernelBench/level1/39_L2Norm_.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 128
       DIM: 512

--- a/problems/specs/KernelBench/level1/3_Batched_matrix_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/3_Batched_matrix_multiplication.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       M: 64

--- a/problems/specs/KernelBench/level1/40_LayerNorm.yaml
+++ b/problems/specs/KernelBench/level1/40_LayerNorm.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/41_Max_Pooling_1D.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 24

--- a/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/42_Max_Pooling_2D.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       CHANNELS: 8

--- a/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
+++ b/problems/specs/KernelBench/level1/43_Max_Pooling_3D.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       FEATURES: 4

--- a/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
+++ b/problems/specs/KernelBench/level1/44_Average_Pooling_1D.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 32

--- a/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
+++ b/problems/specs/KernelBench/level1/45_Average_Pooling_2D.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       CHANNELS: 16

--- a/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/47_Sum_reduction_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/48_Mean_reduction_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/49_Max_reduction_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/4_Matrix_vector_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/4_Matrix_vector_multiplication_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 1

--- a/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/50_conv_standard_2D__square_input__square_kernel.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       NUM_CLASSES: 10

--- a/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/51_Argmax_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/52_Argmin_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
+++ b/problems/specs/KernelBench/level1/53_Min_reduction_over_a_dimension.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       DIM1: 64

--- a/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/54_conv_standard_3D__square_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/55_conv_standard_2D__asymmetric_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/56_conv_standard_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/57_conv_transposed_2D__square_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 16

--- a/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/58_conv_transposed_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/59_conv_standard_3D__asymmetric_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level1/5_Matrix_scalar_multiplication.yaml
+++ b/problems/specs/KernelBench/level1/5_Matrix_scalar_multiplication.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 64
       N: 32

--- a/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/60_conv_standard_3D__square_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/61_conv_transposed_3D__square_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 24

--- a/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/62_conv_standard_2D__square_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/63_conv_standard_2D__square_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
+++ b/problems/specs/KernelBench/level1/64_conv_transposed_1D.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/65_conv_transposed_2D__square_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/66_conv_standard_3D__asymmetric_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
+++ b/problems/specs/KernelBench/level1/67_conv_standard_1D.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/68_conv_transposed_3D__square_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 2

--- a/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/69_conv_transposed_2D__asymmetric_input__asymmetric_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/6_Matmul_with_large_K_dimension_.yaml
+++ b/problems/specs/KernelBench/level1/6_Matmul_with_large_K_dimension_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 8
       N: 16

--- a/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/70_conv_transposed_3D__asymmetric_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 12

--- a/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/71_conv_transposed_2D__asymmetric_input__square_kernel.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
+++ b/problems/specs/KernelBench/level1/72_conv_transposed_3D_asymmetric_input_asymmetric_kernel___strided_padded_grouped_.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
+++ b/problems/specs/KernelBench/level1/73_conv_transposed_3D_asymmetric_input_square_kernel__strided_padded__grouped.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
+++ b/problems/specs/KernelBench/level1/74_conv_transposed_1D_dilated.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/75_conv_transposed_2D_asymmetric_input_asymmetric_kernel_strided__grouped____padded____dilated__.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
+++ b/problems/specs/KernelBench/level1/76_conv_standard_1D_dilated_strided__.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
+++ b/problems/specs/KernelBench/level1/77_conv_transposed_3D_square_input_square_kernel___padded____dilated____strided__.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
+++ b/problems/specs/KernelBench/level1/78_conv_transposed_2D_asymmetric_input_asymmetric_kernel___padded__.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
+++ b/problems/specs/KernelBench/level1/79_conv_transposed_1D_asymmetric_input_square_kernel___padded____strided____dilated__.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/7_Matmul_with_small_K_dimension_.yaml
+++ b/problems/specs/KernelBench/level1/7_Matmul_with_small_K_dimension_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 256
       N: 256

--- a/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
+++ b/problems/specs/KernelBench/level1/80_conv_standard_2D_square_input_asymmetric_kernel___dilated____padded__.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
+++ b/problems/specs/KernelBench/level1/81_conv_transposed_2D_asymmetric_input_square_kernel___dilated____padded____strided__.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/82_conv_depthwise_2D_square_input_square_kernel.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 16

--- a/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/83_conv_depthwise_2D_square_input_asymmetric_kernel.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
+++ b/problems/specs/KernelBench/level1/84_conv_depthwise_2D_asymmetric_input_square_kernel.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
+++ b/problems/specs/KernelBench/level1/85_conv_depthwise_2D_asymmetric_input_asymmetric_kernel.yaml
@@ -18,7 +18,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
+++ b/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
+++ b/problems/specs/KernelBench/level1/87_conv_pointwise_2D.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
+++ b/problems/specs/KernelBench/level1/88_MinGPTNewGelu.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 32
       DIM: 32

--- a/problems/specs/KernelBench/level1/89_cumsum.yaml
+++ b/problems/specs/KernelBench/level1/89_cumsum.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/8_Matmul_with_irregular_shapes_.yaml
+++ b/problems/specs/KernelBench/level1/8_Matmul_with_irregular_shapes_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 60
       N: 37

--- a/problems/specs/KernelBench/level1/90_cumprod.yaml
+++ b/problems/specs/KernelBench/level1/90_cumprod.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
+++ b/problems/specs/KernelBench/level1/91_cumsum_reverse.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
+++ b/problems/specs/KernelBench/level1/92_cumsum_exclusive.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [x]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/93_masked_cumsum.yaml
+++ b/problems/specs/KernelBench/level1/93_masked_cumsum.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [x, mask]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/94_MSELoss.yaml
+++ b/problems/specs/KernelBench/level1/94_MSELoss.yaml
@@ -11,7 +11,7 @@ inits: []
 
 ci:
   - params: [predictions, targets]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
+++ b/problems/specs/KernelBench/level1/95_CrossEntropyLoss.yaml
@@ -11,7 +11,7 @@ inits: []
 
 ci:
   - params: [predictions, targets]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       NUM_CLASSES: 8

--- a/problems/specs/KernelBench/level1/96_HuberLoss.yaml
+++ b/problems/specs/KernelBench/level1/96_HuberLoss.yaml
@@ -11,7 +11,7 @@ inits: []
 
 ci:
   - params: [predictions, targets]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
+++ b/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
@@ -13,7 +13,7 @@ inits: []
 
 ci:
   - params: [Q, K, V]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       NUM_HEADS: 8

--- a/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
+++ b/problems/specs/KernelBench/level1/98_KLDivLoss.yaml
@@ -12,7 +12,7 @@ inits: []
 
 ci:
   - params: [predictions, targets]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 64

--- a/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
+++ b/problems/specs/KernelBench/level1/99_TripletMarginLoss.yaml
@@ -15,7 +15,7 @@ inits:
 
 ci:
   - params: [anchor, positive, negative]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 64
       INPUT_DIM: 8

--- a/problems/specs/KernelBench/level1/9_Tall_skinny_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/9_Tall_skinny_matrix_multiplication_.yaml
@@ -8,7 +8,7 @@ inputs:
 
 ci:
   - params: [A, B]
-    dtype: float16
+    dtype: float32
     dims:
       M: 256
       N: 16

--- a/problems/specs/KernelBench/level2/100_ConvTranspose3d_Clamp_Min_Divide.yaml
+++ b/problems/specs/KernelBench/level2/100_ConvTranspose3d_Clamp_Min_Divide.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/10_ConvTranspose2d_MaxPool_Hardtanh_Mean_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/10_ConvTranspose2d_MaxPool_Hardtanh_Mean_Tanh.yaml
@@ -16,7 +16,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/11_ConvTranspose2d_BatchNorm_Tanh_MaxPool_GroupNorm.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/12_Gemm_Multiply_LeakyReLU.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/13_ConvTranspose3d_Mean_Add_Softmax_Tanh_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/13_ConvTranspose3d_Mean_Add_Softmax_Tanh_Scaling.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_SIZE: 64

--- a/problems/specs/KernelBench/level2/15_ConvTranspose3d_BatchNorm_Subtract.yaml
+++ b/problems/specs/KernelBench/level2/15_ConvTranspose3d_BatchNorm_Subtract.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/16_ConvTranspose2d_Mish_Add_Hardtanh_Scaling.yaml
@@ -15,7 +15,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/17_Conv2d_InstanceNorm_Divide.yaml
+++ b/problems/specs/KernelBench/level2/17_Conv2d_InstanceNorm_Divide.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 64

--- a/problems/specs/KernelBench/level2/19_ConvTranspose2d_GELU_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/19_ConvTranspose2d_GELU_GroupNorm.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_CHANNELS: 16

--- a/problems/specs/KernelBench/level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/20_ConvTranspose3d_Sum_ResidualAdd_Multiply_ResidualAdd.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/21_Conv2d_Add_Scale_Sigmoid_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/21_Conv2d_Add_Scale_Sigmoid_GroupNorm.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.yaml
+++ b/problems/specs/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 64

--- a/problems/specs/KernelBench/level2/23_Conv3d_GroupNorm_Mean.yaml
+++ b/problems/specs/KernelBench/level2/23_Conv3d_GroupNorm_Mean.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/24_Conv3d_Min_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/24_Conv3d_Min_Softmax.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/25_Conv2d_Min_Tanh_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/25_Conv2d_Min_Tanh_Tanh.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 2

--- a/problems/specs/KernelBench/level2/26_ConvTranspose3d_Add_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/26_ConvTranspose3d_Add_HardSwish.yaml
@@ -17,7 +17,7 @@ inits:
 
 ci:
   - params: [X, ADD_INPUT]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/27_Conv3d_HardSwish_GroupNorm_Mean.yaml
+++ b/problems/specs/KernelBench/level2/27_Conv3d_HardSwish_GroupNorm_Mean.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/28_BMM_InstanceNorm_Sum_ResidualAdd_Multiply.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X, Y]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 64

--- a/problems/specs/KernelBench/level2/29_Matmul_Mish_Mish.yaml
+++ b/problems/specs/KernelBench/level2/29_Matmul_Mish_Mish.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 64

--- a/problems/specs/KernelBench/level2/2_ConvTranspose2d_BiasAdd_Clamp_Scaling_Clamp_Divide.yaml
+++ b/problems/specs/KernelBench/level2/2_ConvTranspose2d_BiasAdd_Clamp_Scaling_Clamp_Divide.yaml
@@ -15,7 +15,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.yaml
+++ b/problems/specs/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 64

--- a/problems/specs/KernelBench/level2/31_Conv2d_Min_Add_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/31_Conv2d_Min_Add_Multiply.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/32_Conv2d_Scaling_Min.yaml
+++ b/problems/specs/KernelBench/level2/32_Conv2d_Scaling_Min.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/33_Gemm_Scale_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/33_Gemm_Scale_BatchNorm.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/34_ConvTranspose3d_LayerNorm_GELU_Scaling.yaml
@@ -15,7 +15,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.yaml
+++ b/problems/specs/KernelBench/level2/35_Conv2d_Subtract_HardSwish_MaxPool_Mish.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/36_ConvTranspose2d_Min_Sum_GELU_Add.yaml
+++ b/problems/specs/KernelBench/level2/36_ConvTranspose2d_Min_Sum_GELU_Add.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 8

--- a/problems/specs/KernelBench/level2/39_Gemm_Scale_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/39_Gemm_Scale_BatchNorm.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/40_Matmul_Scaling_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/40_Matmul_Scaling_ResidualAdd.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/42_ConvTranspose2d_GlobalAvgPool_BiasAdd_LogSumExp_Sum_Multiply.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/43_Conv3d_Max_LogSumExp_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/43_Conv3d_Max_LogSumExp_ReLU.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.yaml
+++ b/problems/specs/KernelBench/level2/44_ConvTranspose2d_Multiply_GlobalAvgPool_GlobalAvgPool_Mean.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.yaml
+++ b/problems/specs/KernelBench/level2/46_Conv2d_Subtract_Tanh_Subtract_AvgPool.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/47_Conv3d_Mish_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/47_Conv3d_Mish_Tanh.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/48_Conv3d_Scaling_Tanh_Multiply_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/48_Conv3d_Scaling_Tanh_Multiply_Sigmoid.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/49_ConvTranspose3d_Softmax_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/49_ConvTranspose3d_Softmax_Sigmoid.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/4_Conv2d_Mish_Mish.yaml
+++ b/problems/specs/KernelBench/level2/4_Conv2d_Mish_Mish.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/52_Conv2d_Activation_BatchNorm.yaml
+++ b/problems/specs/KernelBench/level2/52_Conv2d_Activation_BatchNorm.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/53_Gemm_Scaling_Hardtanh_GELU.yaml
+++ b/problems/specs/KernelBench/level2/53_Gemm_Scaling_Hardtanh_GELU.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/54_Conv2d_Multiply_LeakyReLU_GELU.yaml
+++ b/problems/specs/KernelBench/level2/54_Conv2d_Multiply_LeakyReLU_GELU.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.yaml
+++ b/problems/specs/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/56_Matmul_Sigmoid_Sum.yaml
+++ b/problems/specs/KernelBench/level2/56_Matmul_Sigmoid_Sum.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level2/57_Conv2d_ReLU_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/57_Conv2d_ReLU_HardSwish.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/58_ConvTranspose3d_LogSumExp_HardSwish_Subtract_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/58_ConvTranspose3d_LogSumExp_HardSwish_Subtract_Clamp.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/59_Matmul_Swish_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/59_Matmul_Swish_Scaling.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/5_ConvTranspose2d_Subtract_Tanh.yaml
+++ b/problems/specs/KernelBench/level2/5_ConvTranspose2d_Subtract_Tanh.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.yaml
+++ b/problems/specs/KernelBench/level2/60_ConvTranspose3d_Swish_GroupNorm_HardSwish.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/61_ConvTranspose3d_ReLU_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/61_ConvTranspose3d_ReLU_GroupNorm.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.yaml
+++ b/problems/specs/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level2/63_Gemm_ReLU_Divide.yaml
+++ b/problems/specs/KernelBench/level2/63_Gemm_ReLU_Divide.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.yaml
+++ b/problems/specs/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/65_Conv2d_AvgPool_Sigmoid_Sum.yaml
+++ b/problems/specs/KernelBench/level2/65_Conv2d_AvgPool_Sigmoid_Sum.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/66_Matmul_Dropout_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/66_Matmul_Dropout_Softmax.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/67_Conv2d_GELU_GlobalAvgPool.yaml
+++ b/problems/specs/KernelBench/level2/67_Conv2d_GELU_GlobalAvgPool.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 12
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/68_Matmul_Min_Subtract.yaml
+++ b/problems/specs/KernelBench/level2/68_Matmul_Min_Subtract.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/69_Conv2d_HardSwish_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/69_Conv2d_HardSwish_ReLU.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/6_Conv3d_Softmax_MaxPool_MaxPool.yaml
+++ b/problems/specs/KernelBench/level2/6_Conv3d_Softmax_MaxPool_MaxPool.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/70_Gemm_Sigmoid_Scaling_ResidualAdd.yaml
+++ b/problems/specs/KernelBench/level2/70_Gemm_Sigmoid_Scaling_ResidualAdd.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level2/71_Conv2d_Divide_LeakyReLU.yaml
+++ b/problems/specs/KernelBench/level2/71_Conv2d_Divide_LeakyReLU.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/73_Conv2d_BatchNorm_Scaling.yaml
+++ b/problems/specs/KernelBench/level2/73_Conv2d_BatchNorm_Scaling.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.yaml
+++ b/problems/specs/KernelBench/level2/74_ConvTranspose3d_LeakyReLU_Multiply_LeakyReLU_Max.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/76_Gemm_Add_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/76_Gemm_Add_ReLU.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.yaml
+++ b/problems/specs/KernelBench/level2/77_ConvTranspose3d_Scale_BatchNorm_GlobalAvgPool.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/78_ConvTranspose3d_Max_Max_Sum.yaml
+++ b/problems/specs/KernelBench/level2/78_ConvTranspose3d_Max_Max_Sum.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/79_Conv3d_Multiply_InstanceNorm_Clamp_Multiply_Max.yaml
+++ b/problems/specs/KernelBench/level2/79_Conv3d_Multiply_InstanceNorm_Clamp_Multiply_Max.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/7_Conv3d_ReLU_LeakyReLU_GELU_Sigmoid_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/7_Conv3d_ReLU_LeakyReLU_GELU_Sigmoid_BiasAdd.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/80_Gemm_Max_Subtract_GELU.yaml
+++ b/problems/specs/KernelBench/level2/80_Gemm_Max_Subtract_GELU.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/81_Gemm_Swish_Divide_Clamp_Tanh_Clamp.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/82_Conv2d_Tanh_Scaling_BiasAdd_Max.yaml
+++ b/problems/specs/KernelBench/level2/82_Conv2d_Tanh_Scaling_BiasAdd_Max.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/83_Conv3d_GroupNorm_Min_Clamp_Dropout.yaml
+++ b/problems/specs/KernelBench/level2/83_Conv3d_GroupNorm_Min_Clamp_Dropout.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/86_Matmul_Divide_GELU.yaml
+++ b/problems/specs/KernelBench/level2/86_Matmul_Divide_GELU.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level2/87_Conv2d_Subtract_Subtract_Mish.yaml
+++ b/problems/specs/KernelBench/level2/87_Conv2d_Subtract_Subtract_Mish.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.yaml
+++ b/problems/specs/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/89_ConvTranspose3d_MaxPool_Softmax_Subtract_Swish_Max.yaml
+++ b/problems/specs/KernelBench/level2/89_ConvTranspose3d_MaxPool_Softmax_Subtract_Swish_Max.yaml
@@ -16,7 +16,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.yaml
+++ b/problems/specs/KernelBench/level2/8_Conv3d_Divide_Max_GlobalAvgPool_BiasAdd_Sum.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/90_Conv3d_LeakyReLU_Sum_Clamp_GELU.yaml
+++ b/problems/specs/KernelBench/level2/90_Conv3d_LeakyReLU_Sum_Clamp_GELU.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/91_ConvTranspose2d_Softmax_BiasAdd_Scaling_Sigmoid.yaml
+++ b/problems/specs/KernelBench/level2/91_ConvTranspose2d_Softmax_BiasAdd_Scaling_Sigmoid.yaml
@@ -15,7 +15,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp.yaml
+++ b/problems/specs/KernelBench/level2/92_Conv2d_GroupNorm_Tanh_HardSwish_ResidualAdd_LogSumExp.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.yaml
+++ b/problems/specs/KernelBench/level2/93_ConvTranspose2d_Add_Min_GELU_Multiply.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.yaml
+++ b/problems/specs/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_FEATURES: 32

--- a/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
+++ b/problems/specs/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/96_ConvTranspose3d_Multiply_Max_GlobalAvgPool_Clamp.yaml
+++ b/problems/specs/KernelBench/level2/96_ConvTranspose3d_Multiply_Max_GlobalAvgPool_Clamp.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
+++ b/problems/specs/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
+++ b/problems/specs/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
+++ b/problems/specs/KernelBench/level2/99_Matmul_GELU_Softmax.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
+++ b/problems/specs/KernelBench/level2/9_Matmul_Subtract_Multiply_ReLU.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_FEAT: 64

--- a/problems/specs/KernelBench/level3/10_ResNet101.yaml
+++ b/problems/specs/KernelBench/level3/10_ResNet101.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/11_VGG16.yaml
+++ b/problems/specs/KernelBench/level3/11_VGG16.yaml
@@ -7,9 +7,9 @@ inits:
   - dim: NUM_CLASSES
 
 # TODO: Reenable for CI
-SKIP: # Compute too long for local use
+ci: # Compute too long for local use
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/11_VGG16.yaml
+++ b/problems/specs/KernelBench/level3/11_VGG16.yaml
@@ -6,8 +6,7 @@ inputs:
 inits:
   - dim: NUM_CLASSES
 
-# TODO: Reenable for CI
-ci: # Compute too long for local use
+ci:
   - params: [X]
     dtype: float32
     dims:

--- a/problems/specs/KernelBench/level3/12_VGG19.yaml
+++ b/problems/specs/KernelBench/level3/12_VGG19.yaml
@@ -7,9 +7,9 @@ inits:
   - dim: NUM_CLASSES
 
 # TODO: Reenable for CI
-SKIP: # Compute too long for local use
+ci: # Compute too long for local use
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/12_VGG19.yaml
+++ b/problems/specs/KernelBench/level3/12_VGG19.yaml
@@ -6,8 +6,7 @@ inputs:
 inits:
   - dim: NUM_CLASSES
 
-# TODO: Reenable for CI
-ci: # Compute too long for local use
+ci:
   - params: [X]
     dtype: float32
     dims:

--- a/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
+++ b/problems/specs/KernelBench/level3/13_DenseNet121TransitionLayer.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       NUM_INPUT_FEATURES: 4

--- a/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
+++ b/problems/specs/KernelBench/level3/14_DenseNet121DenseBlock.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       NUM_INPUT_FEATURES: 2

--- a/problems/specs/KernelBench/level3/15_DenseNet121.yaml
+++ b/problems/specs/KernelBench/level3/15_DenseNet121.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/16_DenseNet201.yaml
+++ b/problems/specs/KernelBench/level3/16_DenseNet201.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
+++ b/problems/specs/KernelBench/level3/17_SqueezeNetFireModule.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
+++ b/problems/specs/KernelBench/level3/18_SqueezeNet.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
+++ b/problems/specs/KernelBench/level3/19_MobileNetV1.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/1_MLP.yaml
+++ b/problems/specs/KernelBench/level3/1_MLP.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 4
       IN_SIZE: 32

--- a/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
+++ b/problems/specs/KernelBench/level3/20_MobileNetV2.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
+++ b/problems/specs/KernelBench/level3/21_EfficientNetMBConv.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 7

--- a/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
+++ b/problems/specs/KernelBench/level3/22_EfficientNetB0.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
+++ b/problems/specs/KernelBench/level3/23_EfficientNetB1.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
+++ b/problems/specs/KernelBench/level3/24_EfficientNetB2.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 2
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
+++ b/problems/specs/KernelBench/level3/25_ShuffleNetUnit.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 30

--- a/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
+++ b/problems/specs/KernelBench/level3/26_ShuffleNet.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/27_RegNet.yaml
+++ b/problems/specs/KernelBench/level3/27_RegNet.yaml
@@ -11,7 +11,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/28_VisionTransformer.yaml
@@ -17,7 +17,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       CHANNELS: 3

--- a/problems/specs/KernelBench/level3/29_SwinMLP.yaml
+++ b/problems/specs/KernelBench/level3/29_SwinMLP.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
+++ b/problems/specs/KernelBench/level3/2_ShallowWideMLP.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 4
       IN_SIZE: 32

--- a/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
+++ b/problems/specs/KernelBench/level3/30_SwinTransformerV2.yaml
@@ -7,7 +7,7 @@ inits: []
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/31_VisionAttention.yaml
+++ b/problems/specs/KernelBench/level3/31_VisionAttention.yaml
@@ -9,7 +9,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       EMBED_DIM: 16

--- a/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
+++ b/problems/specs/KernelBench/level3/32_ConvolutionalVisionTransformer.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
+++ b/problems/specs/KernelBench/level3/33_VanillaRNN.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, INITIAL_HIDDEN]
-    dtype: float32 # TODO: Fix model dtype
+    dtype: float32
     dims:
       BATCH_SIZE: 256
       INPUT_SIZE: 32

--- a/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
+++ b/problems/specs/KernelBench/level3/34_VanillaRNNHidden.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, H0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_SIZE: 64

--- a/problems/specs/KernelBench/level3/35_LSTM.yaml
+++ b/problems/specs/KernelBench/level3/35_LSTM.yaml
@@ -18,7 +18,7 @@ inits:
 
 ci:
   - params: [X, H0, C0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/36_LSTMHn.yaml
+++ b/problems/specs/KernelBench/level3/36_LSTMHn.yaml
@@ -18,7 +18,7 @@ inits:
 
 ci:
   - params: [X, H0, C0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/37_LSTMCn.yaml
+++ b/problems/specs/KernelBench/level3/37_LSTMCn.yaml
@@ -18,7 +18,7 @@ inits:
 
 ci:
   - params: [X, H0, C0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/38_LSTMBidirectional.yaml
@@ -18,7 +18,7 @@ inits:
 
 ci:
   - params: [X, H0, C0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/39_GRU.yaml
+++ b/problems/specs/KernelBench/level3/39_GRU.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, H0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
+++ b/problems/specs/KernelBench/level3/3_DeepNarrowMLP.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 8
       IN_SIZE: 64

--- a/problems/specs/KernelBench/level3/40_GRUHidden.yaml
+++ b/problems/specs/KernelBench/level3/40_GRUHidden.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, H0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
+++ b/problems/specs/KernelBench/level3/41_GRUBidirectional.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, H0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
+++ b/problems/specs/KernelBench/level3/42_GRUBidirectionalHidden.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X, H0]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
+++ b/problems/specs/KernelBench/level3/43_MinGPTCausalAttention.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       MAX_SEQLEN: 128

--- a/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
+++ b/problems/specs/KernelBench/level3/44_MiniGPTBlock.yaml
@@ -12,7 +12,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
+++ b/problems/specs/KernelBench/level3/45_UNetSoftmax.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 8

--- a/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/46_NetVladWithGhostClusters.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       NUM_FEATURES: 10

--- a/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
+++ b/problems/specs/KernelBench/level3/47_NetVladNoGhostClusters.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       NUM_FEATURES: 10

--- a/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
+++ b/problems/specs/KernelBench/level3/48_Mamba2ReturnY.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQ_LENGTH: 32

--- a/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
+++ b/problems/specs/KernelBench/level3/49_Mamba2ReturnFinalState.yaml
@@ -13,7 +13,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQ_LENGTH: 32

--- a/problems/specs/KernelBench/level3/4_LeNet5.yaml
+++ b/problems/specs/KernelBench/level3/4_LeNet5.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       IN_1: 1

--- a/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
+++ b/problems/specs/KernelBench/level3/50_ReLUSelfAttention.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       SEQUENCE_LENGTH: 32

--- a/problems/specs/KernelBench/level3/5_AlexNet.yaml
+++ b/problems/specs/KernelBench/level3/5_AlexNet.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 1
       IN_1: 3

--- a/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
+++ b/problems/specs/KernelBench/level3/6_GoogleNetInceptionModule.yaml
@@ -14,7 +14,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       IN_CHANNELS: 2
       OUT_1x1: 16

--- a/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
+++ b/problems/specs/KernelBench/level3/7_GoogleNetInceptionV1.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
+++ b/problems/specs/KernelBench/level3/8_ResNetBasicBlock.yaml
@@ -10,7 +10,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH_SIZE: 1
       IN_CHANNELS: 3

--- a/problems/specs/KernelBench/level3/9_ResNet18.yaml
+++ b/problems/specs/KernelBench/level3/9_ResNet18.yaml
@@ -8,7 +8,7 @@ inits:
 
 ci:
   - params: [X]
-    dtype: float16
+    dtype: float32
     dims:
       BATCH: 2
       NUM_CLASSES: 4


### PR DESCRIPTION
Speeds up the default problems' CI variant to float32 type to speed up testing on CPU.
Thanks to the speedup, KernelBench level3 problems 11 and 12 are reenabled for CI runs.