### PR TITLE
[problems] Switch bench CPU variants to bfloat16

### DIFF
--- a/problems/specs/KernelBench/level1/19_ReLU.yaml
+++ b/problems/specs/KernelBench/level1/19_ReLU.yaml
@@ -12,7 +12,7 @@ ci:
 
 bench-cpu:
   - params: [X]
-    dtype: float16
+    dtype: bfloat16
     dims:
       BATCH: 128
       DIM: 2048

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -14,7 +14,7 @@ ci:
 
 bench-cpu:
   - params: [A, B]
-    dtype: float16
+    dtype: bfloat16
     dims:
       N: 256
     flop: "2*N*N*N"

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -16,7 +16,7 @@ ci:
 
 bench-cpu:
   - params: [A, B]
-    dtype: float16
+    dtype: bfloat16
     dims:
       M: 128
       N: 256


### PR DESCRIPTION
Switches CPU benchmarks to bfloat16 as this data type has more hardware acceleration support compared to the previously used float16.