### PR TITLE
[harness] MLIR backend

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -3,8 +3,12 @@ name: KernelBench Perf
 on:
   workflow_dispatch:
     inputs:
-      RUN_CPU:
-        description: "Run on CPU"
+      RUN_CPU_TORCH:
+        description: "Run on CPU (PyTorch eager)"
+        type: boolean
+        default: false
+      RUN_CPU_MLIR:
+        description: "Run on CPU (MLIR)"
         type: boolean
         default: false
       RUN_XPU_TORCH:
@@ -29,10 +33,10 @@ env:
   SRUN: ${HOME}/srun.sh
 
 jobs:
-  CPU:
+  CPU-PyTorch:
     runs-on: pcl-tiergarten
     if: |
-      (github.event_name == 'workflow_dispatch' && inputs.RUN_CPU)
+      (github.event_name == 'workflow_dispatch' && inputs.RUN_CPU_TORCH)
 
     steps:
       - uses: actions/checkout@v5
@@ -40,6 +44,18 @@ jobs:
       - name: Intel Emerald Rapids
         run: "${{ env.SRUN }} --partition=emr --time=0:15:00 --constraint=\"notrb\" -- \
             '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -b torch'"
+
+  CPU-MLIR:
+    runs-on: pcl-tiergarten
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.RUN_CPU_MLIR)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Intel Emerald Rapids
+        run: "${{ env.SRUN }} --partition=emr --time=0:15:00 --constraint=\"notrb\" -- \
+            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -b mlir'"
 
   XPU-PyTorch:
     runs-on: pcl-tiergarten

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![KernelBench Perf](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml/badge.svg)](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml)
 ![Status](https://img.shields.io/badge/status-beta-yellow)
 
-A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion) and devices (CPU, XPU).
+A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR) and devices (CPU, XPU).
 
 ## Installation
 
@@ -17,7 +17,7 @@ The project is using [uv](https://docs.astral.sh/uv/) package manager.
 pip install uv
 ```
 
-The project can be installed with appropriate device-specific extensions using:
+The project can be installed with appropriate device and backend extensions using:
 
 ```bash
 # CPU only
@@ -25,6 +25,9 @@ uv sync --extra cpu
 
 # CPU + XPU
 uv sync --extra xpu
+
+# CPU + MLIR backend
+uv sync --extra cpu --extra mlir
 ```
 
 ## Usage
@@ -39,6 +42,9 @@ ai-bench --help
 
 # PyTorch on CPU (default)
 ai-bench
+
+# MLIR on CPU
+ai-bench --mlir
 
 # PyTorch on XPU
 ai-bench --xpu
@@ -149,6 +155,8 @@ Notes legend:
 | `--xpu` | Run on Intel XPU (default: CPU) |
 | `--triton` | Use Triton backend (default: PyTorch eager) |
 | `--torch-compile` | Use PyTorch compile mode (default: PyTorch eager) |
+| `--helion` | Use Helion backend (default: PyTorch eager) |
+| `--mlir` | Use MLIR backend (default: PyTorch eager) |
 | `--bench` | Run benchmarks with timing (default: CI validation) |
 | `--gflops` | Report GFLOPS (default: TFLOPS) |
 | `--mbs` | Report MB/s (default: GB/s) |
@@ -158,6 +166,7 @@ Notes legend:
 | `--kernels-dir PATH` | Path to kernels directory (CLI only) |
 | `--triton-kernels-dir PATH` | Path to Triton kernels directory (CLI only) |
 | `--helion-kernels-dir PATH` | Path to Helion kernels directory (CLI only) |
+| `--mlir-kernels-dir PATH` | Path to MLIR kernels directory (CLI only) |
 | `--env-file PATH` | Path to .env file (default: auto-detect) |
 | `--no-env` | Disable loading .env config |
 
@@ -190,6 +199,10 @@ Environment variables used for project configuration:
 | `AIBENCH_KERNELS_DIR` | Path to PyTorch kernels directory |
 | `AIBENCH_TRITON_KERNELS_DIR` | Path to Triton kernels directory |
 | `AIBENCH_HELION_KERNELS_DIR` | Path to Helion kernels directory |
+| `AIBENCH_MLIR_KERNELS_DIR` | Path to MLIR kernels directory |
+| `AIBENCH_MLIR_LIB_PATH` | Paths to MLIR shared libraries (colon separated) |
+| `AIBENCH_MLIR_DUMP` | Dump imported MLIR IR |
+| `AIBENCH_MLIR_DUMP_OBJ` | Dump jitted MLIR to an object file |
 
 ## License
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -35,6 +35,9 @@ Examples:
   # Run with Helion backend
   ai-bench --xpu --bench --helion
 
+  # Run with MLIR backend
+  ai-bench --bench --mlir
+
   # Save results to CSV
   ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
@@ -121,6 +124,12 @@ Environment file (.env) example:
         default=None,
         help="Path to Helion kernels directory (default: auto-detect or AIBENCH_HELION_KERNELS_DIR)",
     )
+    path_group.add_argument(
+        "--mlir-kernels-dir",
+        type=Path,
+        default=None,
+        help="Path to MLIR kernels directory (default: auto-detect or AIBENCH_MLIR_KERNELS_DIR)",
+    )
 
     # Device options
     device_group = parser.add_argument_group("device options")
@@ -157,6 +166,12 @@ Environment file (.env) example:
         action="store_true",
         default=False,
         help="Use Helion backend",
+    )
+    backend_exclusive.add_argument(
+        "--mlir",
+        action="store_true",
+        default=False,
+        help="Use MLIR backend",
     )
 
     # Run mode
@@ -228,12 +243,14 @@ def main(argv: list[str] | None = None) -> int:
         or args.kernels_dir
         or args.triton_kernels_dir
         or args.helion_kernels_dir
+        or args.mlir_kernels_dir
     ):
         finder.configure(
             specs_dir=args.specs_dir,
             kernels_dir=args.kernels_dir,
             triton_kernels_dir=args.triton_kernels_dir,
             helion_kernels_dir=args.helion_kernels_dir,
+            mlir_kernels_dir=args.mlir_kernels_dir,
         )
 
     # Determine device
@@ -251,6 +268,8 @@ def main(argv: list[str] | None = None) -> int:
         backend = core.Backend.HELION
     elif args.torch_compile:
         backend = core.Backend.PYTORCH_COMPILE
+    elif args.mlir:
+        backend = core.Backend.MLIR
     else:
         backend = core.Backend.PYTORCH
 

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -70,6 +70,7 @@ class Backend(StrEnum):
     PYTORCH_COMPILE = "pytorch-compile"
     TRITON = "triton"
     HELION = "helion"
+    MLIR = "mlir"
 
 
 def input_shape(input_entry: dict, dims: Dict[str, int]) -> list[int]:

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -78,6 +78,10 @@ class KernelBenchRunner(KernelRunner):
             self.kernels = ai_utils.triton_kernels_dir() / "KernelBench"
         elif self.backend == ai_hc.Backend.HELION:
             self.kernels = ai_utils.helion_kernels_dir() / "KernelBench"
+        elif self.backend == ai_hc.Backend.MLIR:
+            self.kernels = (
+                ai_utils.mlir_kernels_dir() / self.device.type / "KernelBench"
+            )
         else:
             raise ValueError(f"Unsupported backend: {self.backend}")
 

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -74,10 +74,10 @@ class KernelRunner:
 
         self.spec_type = spec_type
         self.device = device if device else torch.device("cpu")
-        if self.device.type == "cpu":
+        if self.is_cpu():
             self.warmup = 5
             self.rep = 20
-        elif self.device.type == "xpu":
+        elif self.is_xpu():
             self.warmup = 200
             self.rep = 100
         else:
@@ -90,6 +90,14 @@ class KernelRunner:
             True if the current backend is torch-based.
         """
         return self.backend in [ai_hc.Backend.PYTORCH, ai_hc.Backend.PYTORCH_COMPILE]
+
+    def is_cpu(self) -> bool:
+        """Check if the device is a CPU."""
+        return self.device.type == "cpu"
+
+    def is_xpu(self) -> bool:
+        """Check if the device is an XPU."""
+        return self.device.type == "xpu"
 
     def load_model(self, kernel_path: Path) -> types.ModuleType | None:
         """Load a kernel model.
@@ -180,7 +188,9 @@ class KernelRunner:
             if self.backend == ai_hc.Backend.PYTORCH_COMPILE:
                 model = torch.compile(model, dynamic=False)
 
-            fn = model.forward
+            # Call model directly to avoid skipping extra hooks if present.
+            # It allows 'torch.compile' decorator to be invoked correctly.
+            fn = model
             args = ai_hc.get_inputs(variant, inputs, device=self.device)
 
             # Simple CI run to verify functionality.

--- a/ai_bench/mlir/__init__.py
+++ b/ai_bench/mlir/__init__.py
@@ -1,0 +1,5 @@
+from .compile import cpu_backend
+
+__all__ = [
+    "cpu_backend",
+]

--- a/ai_bench/mlir/compile.py
+++ b/ai_bench/mlir/compile.py
@@ -1,0 +1,321 @@
+from collections.abc import Callable
+from collections.abc import Sequence
+import contextlib
+from dataclasses import dataclass
+import os
+
+from lighthouse import utils as lh_utils
+from lighthouse.ingress.torch import import_from_model
+from mlir import ir
+from mlir.dialects import bufferization
+from mlir.dialects import func
+from mlir.execution_engine import ExecutionEngine
+import torch
+from torch_mlir.fx import OutputType
+
+from ai_bench.utils.logger import setup_logger
+
+
+@dataclass
+class BufferMetadata:
+    """Data buffer metadata."""
+
+    shape: list[int]
+    dtype: torch.dtype
+    device: torch.device
+
+
+class JITFunction:
+    """
+    Wrapper around JIT-compiled MLIR function.
+
+    Manages lifetime of the compiled code and allocates result buffers.
+
+    Args:
+        module: MLIR module containing LLVM IR ops.
+        results: Metadata of expected output buffers.
+        shared_libs: Paths to external runtime libraries used to execute
+            compiled MLIR function.
+        entry_func: Name of entry function.
+    """
+
+    def __init__(
+        self,
+        module: ir.Module,
+        results: list[BufferMetadata],
+        shared_libs: Sequence[str] = [],
+        entry_func: str = "main",
+    ):
+        self.eng = ExecutionEngine(module, opt_level=3, shared_libs=shared_libs)
+        self.eng.initialize()
+        self.fn = self.eng.lookup(entry_func)
+        self.results = results
+        if os.environ.get("AIBENCH_MLIR_DUMP_OBJ"):
+            import uuid
+
+            file = "jit-mlir-dump-" + uuid.uuid4().hex + ".o"
+            self.eng.dump_to_object_file(file)
+            logger = setup_logger()
+            logger.info(f"--- MLIR JIT - Created object file: {file}")
+
+    def __call__(
+        self,
+        *args: torch.Tensor,
+    ) -> list[torch.Tensor]:
+        """
+        Allocate result buffers and call the jitted function.
+
+        Args:
+            args: Input tensors.
+
+        Returns:
+            Result tensors.
+        """
+        # Allocate empty buffers to store results.
+        outs = [
+            torch.empty(res.shape, dtype=res.dtype, device=res.device)
+            for res in self.results
+        ]
+
+        # Prepare arguments according to MLIR backend's calling convention:
+        # input data followed by output storage buffers.
+        mlir_args = list(args)
+        mlir_args.extend(outs)
+        mlir_args = lh_utils.torch.to_packed_args(mlir_args)
+        self.fn(mlir_args)
+
+        return outs
+
+
+class MLIRBackend:
+    """
+    A PyTorch backend via MLIR.
+
+    The backend exports PyTorch models into MLIR module. The entry function is
+    first preprocessed to simplify data management. Notably:
+      - MLIR entry function is marked private to enable more optimizations
+      - MLIR result buffers are moved into arguments
+    Use of output argument prevents need for cross Python-MLIR buffer lifetime
+    handling. The output buffer are allocated outside of MLIR (see 'JITFunction')
+    on the target device.
+
+    Then the provided compilation function partially lowers the imported program
+    to LLVM IR dialect before the final executable is created.
+
+    Args:
+        device: Target device.
+        fn_compile: Function to lower imported MLIR to LLVM IR dialect.
+        dialect: The target dialect for MLIR IR imported from PyTorch model.
+        ir_context: An optional MLIR context to use for compilation.
+            If not provided, a new default context is created.
+        shared_libs: Paths to external runtime libraries used to execute
+            compiled MLIR function. Extra paths provided through environment
+            variable are also included.
+        entry_func: Name of entry function.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        fn_compile: Callable[[ir.Module], ir.Module],
+        dialect: OutputType | str = OutputType.LINALG_ON_TENSORS,
+        ir_context: ir.Context | None = None,
+        shared_libs: Sequence[str] = [],
+        entry_func: str = "main",
+    ):
+        if dialect not in [
+            OutputType.LINALG_ON_TENSORS,
+            OutputType.TOSA,
+            OutputType.STABLEHLO,
+        ]:
+            raise ValueError(f"Unsupported backend dialect: {dialect}")
+
+        self.device = device
+        self.fn_compile = fn_compile
+        self.dialect = OutputType.get(dialect)
+        self.ctx = ir_context if ir_context is not None else ir.Context()
+        self.shared_libs = list(shared_libs)
+        lib_paths = os.environ.get("AIBENCH_MLIR_LIB_PATH")
+        if lib_paths:
+            libs = lib_paths.split(":")
+            self.shared_libs.extend(libs)
+        self.entry_func = entry_func
+        self.logger = setup_logger()
+
+    def get_entry_func(self, module: ir.Module) -> func.FuncOp | None:
+        """
+        Find entry function in MLIR module.
+
+        Args:
+            module: MLIR module.
+
+        Returns:
+            Entry function operation if present, None otherwise.
+        """
+        assert len(module.operation.regions) == 1, "Expected module with one region"
+        assert len(module.operation.regions[0].blocks) == 1, (
+            "Expected module with one block"
+        )
+
+        for op in module.operation.regions[0].blocks[0].operations:
+            if (
+                isinstance(op.opview, func.FuncOp)
+                and op.opview.name.value == self.entry_func
+            ):
+                return op.opview
+        return None
+
+    def get_results(self, func_op: func.FuncOp) -> list[BufferMetadata]:
+        """
+        Extract metadata about function operation results.
+
+        Args:
+            func_op: MLIR function op.
+
+        Returns:
+            A list of metadata per result.
+        """
+        results = []
+        for res in func_op.type.results:
+            assert isinstance(res, ir.RankedTensorType), "Expected ranked tensor output"
+            res_dtype = lh_utils.torch.dtype_from_mlir_type(res.element_type)
+            results.append(
+                BufferMetadata(shape=res.shape, dtype=res_dtype, device=self.device)
+            )
+        return results
+
+    def move_results_to_args(self, func_op: func.FuncOp):
+        """
+        Move function results to arguments.
+        The function is modified in-place.
+
+        Args:
+            func_op: Function op to modify.
+        """
+        results = func_op.type.results
+        if len(results) == 0:
+            return
+
+        assert all(isinstance(res, ir.RankedTensorType) for res in results), (
+            "Expected only ranked tensor results"
+        )
+
+        with func_op.context, func_op.location:
+            # Current bufferization can't handle return op fed by new tensor values
+            # created using 'materialize_in_destination' op (missing region branch
+            # interface).
+            #
+            # Create equivalent memref buffers, instead.
+            # PyTorch tensors are later converted to ranked memrefs anyway.
+            memref_bufs = [
+                ir.MemRefType.get(res.shape, res.element_type) for res in results
+            ]
+
+            # Append results to function args and its block args.
+            new_func_type = ir.FunctionType.get(
+                inputs=[*func_op.type.inputs, *memref_bufs], results=[]
+            )
+            func_op.function_type = ir.TypeAttr.get(new_func_type)
+            for res in memref_bufs:
+                func_op.entry_block.add_argument(res, func_op.location)
+
+            # Ensure outputs are written to the new result arguments.
+            return_op: func.ReturnOp = func_op.entry_block.operations[-1]
+            with (
+                ir.InsertionPoint.at_block_terminator(func_op.entry_block),
+                return_op.location,
+            ):
+                for idx, arg in enumerate(func_op.arguments[-len(results) :]):
+                    bufferization.materialize_in_destination(
+                        None,
+                        return_op.operands[idx],
+                        arg,
+                        restrict=True,
+                        writable=True,
+                    )
+                func.return_([])
+                return_op.erase()
+
+    def is_symbolic(self, tensor: torch.Tensor) -> bool:
+        """Check if a tensor has any symbolic dimensions."""
+        return isinstance(tensor, (torch.SymFloat, torch.SymInt, torch.SymBool))
+
+    def __call__(
+        self, model: torch.fx.GraphModule, example_inputs: list[torch.Tensor]
+    ) -> Callable[[list[torch.Tensor]], list[torch.Tensor]]:
+        """
+        Import a PyTorch model into MLIR and return a compiled function.
+
+        Args:
+            model: Traced PyTorch model.
+            example_inputs: Example input tensors.
+
+        Returns:
+            Callable function.
+        """
+        if any(self.is_symbolic(in_tensor) for in_tensor in example_inputs):
+            raise ValueError(
+                "Dynamic shapes are not supported"
+                " - consider using 'torch.compile(..., dynamic=False)'"
+            )
+
+        # Suppress importer's messages.
+        # 'torch_mlir' prints to STDOUT which can be noisy.
+        with contextlib.redirect_stdout(None):
+            mlir_mod = import_from_model(
+                model,
+                sample_args=example_inputs,
+                dialect=self.dialect,
+                ir_context=self.ctx,
+            )
+        if os.environ.get("AIBENCH_MLIR_DUMP"):
+            self.logger.info("--- MLIR JIT - Imported IR:\n" + str(mlir_mod))
+
+        # Preprocess MLIR entry function.
+        func_op: func.FuncOp = self.get_entry_func(mlir_mod)
+        if func_op is None:
+            raise ValueError(f"Failed to find MLIR entry: {self.entry_func}")
+        # Mark the function private as the symbol will not be exposed externally.
+        # Private functions allow for more rewrites.
+        func_op.sym_visibility = ir.StringAttr.get("private", func_op.context)
+        # Metadata about function returns is stored for later output buffer allocation.
+        results = self.get_results(func_op)
+        # Add extra arguments to store results in external buffers.
+        self.move_results_to_args(func_op)
+
+        # Transform MLIR module.
+        mlir_mod = self.fn_compile(mlir_mod)
+
+        return JITFunction(
+            mlir_mod, results, shared_libs=self.shared_libs, entry_func=self.entry_func
+        )
+
+
+def cpu_backend(
+    fn_compile: Callable[[ir.Module], ir.Module],
+    dialect: OutputType | str = OutputType.LINALG_ON_TENSORS,
+    ir_context: ir.Context | None = None,
+    shared_libs: Sequence[str] = [],
+) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
+    """
+    CPU backend for JIT-compiling a PyTorch model using MLIR.
+
+    Args:
+        fn_compile: Function to compile imported MLIR to LLVM IR dialect.
+            The function accepts an MLIR module, and returns an MLIR module with
+            transformed IR.
+        dialect: The target dialect for MLIR IR imported from PyTorch model.
+        ir_context: An optional MLIR context to use for compilation.
+        shared_libs: Paths to external runtime libraries used to execute
+            compiled MLIR function.
+
+    Returns:
+        object: A PyTorch model or a partially bound decorator.
+    """
+    return MLIRBackend(
+        torch.device("cpu"),
+        fn_compile,
+        dialect=dialect,
+        ir_context=ir_context,
+        shared_libs=shared_libs,
+    )

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -4,6 +4,7 @@ from .finder import ConfigurationError
 from .finder import configure
 from .finder import helion_kernels_dir
 from .finder import kernel_bench_dir
+from .finder import mlir_kernels_dir
 from .finder import project_root
 from .finder import reset_configuration
 from .finder import specs
@@ -24,6 +25,7 @@ __all__ = [
     "helion_kernels_dir",
     "import_from_path",
     "kernel_bench_dir",
+    "mlir_kernels_dir",
     "project_root",
     "reset_configuration",
     "specs",

--- a/ai_bench/utils/finder.py
+++ b/ai_bench/utils/finder.py
@@ -15,6 +15,7 @@ _specs_dir: Path | None = None
 _kernels_dir: Path | None = None
 _triton_kernels_dir: Path | None = None
 _helion_kernels_dir: Path | None = None
+_mlir_kernels_dir: Path | None = None
 _env_loaded: bool = False
 
 
@@ -84,6 +85,7 @@ def configure(
     kernels_dir: Path | str | None = None,
     triton_kernels_dir: Path | str | None = None,
     helion_kernels_dir: Path | str | None = None,
+    mlir_kernels_dir: Path | str | None = None,
 ) -> None:
     """Configure library paths.
 
@@ -94,6 +96,7 @@ def configure(
         kernels_dir: Path to PyTorch kernel implementations
         triton_kernels_dir: Path to Triton kernel implementations
         helion_kernels_dir: Path to Helion kernel implementations
+        mlir_kernels_dir: Path to MLIR kernel implementations
 
     Example:
         >>> import ai_bench
@@ -102,7 +105,12 @@ def configure(
         ...     kernels_dir="/path/to/kernels",
         ... )
     """
-    global _specs_dir, _kernels_dir, _triton_kernels_dir, _helion_kernels_dir
+    global \
+        _specs_dir, \
+        _kernels_dir, \
+        _triton_kernels_dir, \
+        _helion_kernels_dir, \
+        _mlir_kernels_dir
 
     if specs_dir is not None:
         _specs_dir = Path(specs_dir)
@@ -112,6 +120,8 @@ def configure(
         _triton_kernels_dir = Path(triton_kernels_dir)
     if helion_kernels_dir is not None:
         _helion_kernels_dir = Path(helion_kernels_dir)
+    if mlir_kernels_dir is not None:
+        _mlir_kernels_dir = Path(mlir_kernels_dir)
 
 
 def reset_configuration() -> None:
@@ -124,11 +134,13 @@ def reset_configuration() -> None:
         _kernels_dir, \
         _triton_kernels_dir, \
         _helion_kernels_dir, \
+        _mlir_kernels_dir, \
         _env_loaded
     _specs_dir = None
     _kernels_dir = None
     _triton_kernels_dir = None
     _helion_kernels_dir = None
+    _mlir_kernels_dir = None
     _env_loaded = False
 
 
@@ -295,4 +307,33 @@ def helion_kernels_dir() -> Path:
         "AIBENCH_HELION_KERNELS_DIR",
         default,
         "Helion kernels directory",
+    )
+
+
+def mlir_kernels_dir() -> Path:
+    """Path to the MLIR kernels directory.
+
+    Can be configured via:
+    - ai_bench.configure(mlir_kernels_dir=...)
+    - AIBENCH_MLIR_KERNELS_DIR environment variable
+    - Auto-detected from project structure
+
+    Returns:
+        Path to MLIR kernels directory
+
+    Raises:
+        ConfigurationError: If path cannot be determined
+    """
+
+    def default() -> Path:
+        path = project_root() / "backends" / "mlir"
+        if not path.exists():
+            raise FileNotFoundError(f"Default MLIR kernels path not found: {path}")
+        return path
+
+    return _get_path(
+        _mlir_kernels_dir,
+        "AIBENCH_MLIR_KERNELS_DIR",
+        default,
+        "MLIR kernels directory",
     )

--- a/ai_bench/utils/logger.py
+++ b/ai_bench/utils/logger.py
@@ -5,6 +5,8 @@ import os
 def setup_logger(name="ai_bench", level=logging.INFO):
     logger = logging.getLogger(name)
     if not logger.hasHandlers():
+        # Disable propagation due to possible message duplication from PyTorch's logger.
+        logger.propagate = False
         handler = logging.StreamHandler()
         formatter = logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s")
         handler.setFormatter(formatter)

--- a/backends/mlir/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/mlir/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -14,8 +14,19 @@ TILE_SIZE = 64
 
 
 def tile_and_vector_gemm(ctx: ir.Context) -> ir.Module:
+    """
+    Specialized schedule for Linalg operations.
+
+    Tiling and vectorization is progressively applied to
+    achieve SIMD code generation.
+
+    Args:
+        ctx: MLIR context.
+    Returns:
+        MLIR transform module.
+    """
     with ctx, ir.Location.unknown(context=ctx):
-        # Create transform module.
+        # Create a transform module.
         schedule = ir.Module.create()
         schedule.operation.attributes["transform.with_named_sequence"] = (
             ir.UnitAttr.get()
@@ -40,7 +51,7 @@ def tile_and_vector_gemm(ctx: ir.Context) -> ir.Module:
                 mm, tile_sizes=[TILE_SIZE, TILE_SIZE], apply_cleanup=True
             ).results[0]
 
-            # Tile for better vectorization.
+            # Tile buffer initialization for better vectorization.
             tiled_fill = structured.MatchOp.match_op_names(
                 named_seq.bodyTarget, ["linalg.fill"]
             ).result

--- a/backends/mlir/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/mlir/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -1,0 +1,161 @@
+from mlir import ir
+from mlir.dialects import transform
+from mlir.dialects.transform import gpu
+from mlir.dialects.transform import loop
+from mlir.dialects.transform import structured
+from mlir.dialects.transform import vector
+from mlir.passmanager import PassManager
+import torch
+import torch.nn as nn
+
+import ai_bench.mlir
+
+TILE_SIZE = 64
+
+
+def tile_and_vector_gemm(ctx: ir.Context) -> ir.Module:
+    with ctx, ir.Location.unknown(context=ctx):
+        # Create transform module.
+        schedule = ir.Module.create()
+        schedule.operation.attributes["transform.with_named_sequence"] = (
+            ir.UnitAttr.get()
+        )
+        with ir.InsertionPoint(schedule.body):
+            named_seq = transform.NamedSequenceOp(
+                "__transform_main",
+                [transform.any_op_t()],
+                [],
+                arg_attrs=[{"transform.readonly": ir.UnitAttr.get()}],
+            )
+
+        # Create the schedule.
+        with ir.InsertionPoint(named_seq.body):
+            anytype = transform.any_op_t()
+
+            # GEMM tiling.
+            mm = structured.MatchOp.match_op_names(
+                named_seq.bodyTarget, ["linalg.matmul"]
+            ).result
+            tiled_mm = structured.FuseOp(
+                mm, tile_sizes=[TILE_SIZE, TILE_SIZE], apply_cleanup=True
+            ).results[0]
+
+            # Tile for better vectorization.
+            tiled_fill = structured.MatchOp.match_op_names(
+                named_seq.bodyTarget, ["linalg.fill"]
+            ).result
+            reg_fill = structured.TileUsingForOp(
+                tiled_fill, sizes=[1, TILE_SIZE]
+            ).results[0]
+
+            # Register tiling.
+            reg_mm = structured.TileUsingForOp(tiled_mm, sizes=[8, 32, 1]).results[0]
+
+            # Vectorize operations.
+            structured.structured_vectorize(reg_mm, [], create_named_contraction=True)
+            structured.structured_vectorize(reg_fill, [])
+
+            # Loop hoisting.
+            all_loops = structured.MatchOp(
+                anytype,
+                named_seq.bodyTarget,
+                interface=structured.MatchInterfaceEnum.LoopLikeInterface,
+            ).results
+            transform.apply_licm(all_loops)
+            loop.loop_hoist_loop_invariant_subsets(all_loops)
+
+            # Unroll GEMM.
+            with ir.InsertionPoint(
+                transform.ApplyPatternsOp(named_seq.bodyTarget).patterns
+            ):
+                gpu.apply_patterns_gpu_unroll_vectors_subgroup_mma(m=1, n=32, k=1)
+                vector.apply_patterns_vector_cast_away_vector_leading_one_dim()
+                transform.apply_patterns_canonicalization()
+
+            # Lower to broadcast+FMA instructions.
+            with ir.InsertionPoint(
+                transform.ApplyPatternsOp(named_seq.bodyTarget).patterns
+            ):
+                vector.apply_patterns_vector_lower_contraction(
+                    lowering_strategy=vector.VectorContractLowering.OuterProduct
+                )
+                vector.apply_patterns_vector_lower_outerproduct()
+
+            # Cleanup.
+            transform.apply_cse(named_seq.bodyTarget)
+            with ir.InsertionPoint(
+                transform.ApplyPatternsOp(named_seq.bodyTarget).patterns
+            ):
+                transform.apply_patterns_canonicalization()
+
+            transform.yield_()
+    return schedule
+
+
+def lower_to_llvm(module: ir.Module) -> ir.Module:
+    """
+    Lower MLIR ops within the module to MLIR LLVM IR dialect.
+
+    Args:
+        module: MLIR module coming from PyTorch importer.
+    Returns:
+        MLIR module with lowered IR.
+    """
+    pm = PassManager("builtin.module", module.context)
+
+    # Preprocess.
+    # Use standard C interface wrappers for functions.
+    pm.add("func.func(llvm-request-c-wrappers)")
+
+    # Apply schedule.
+    sched = tile_and_vector_gemm(module.context)
+    sched.body.operations[0].apply(module)
+
+    # Bufferize.
+    pm.add("eliminate-empty-tensors")
+    pm.add(
+        "one-shot-bufferize{function-boundary-type-conversion=identity-layout-map bufferize-function-boundaries}"
+    )
+    pm.add("drop-equivalent-buffer-results")
+    pm.add("buffer-deallocation-pipeline")
+    pm.add("convert-bufferization-to-memref")
+    pm.add("cse")
+    pm.add("canonicalize")
+
+    # Lower to LLVM.
+    pm.add("convert-linalg-to-loops")
+    pm.add("expand-strided-metadata")
+    pm.add("canonicalize")
+
+    pm.add("convert-vector-to-scf")
+    pm.add("lower-affine")
+    pm.add("convert-scf-to-cf")
+    pm.add("convert-vector-to-llvm")
+    pm.add("convert-to-llvm")
+    pm.add("reconcile-unrealized-casts")
+
+    # Cleanup
+    pm.add("cse")
+    pm.add("canonicalize")
+
+    # IR is transformed in-place.
+    pm.run(module.operation)
+
+    # Return the same module which now holds LLVM IR dialect ops.
+    return module
+
+
+@torch.compile(dynamic=False, backend=ai_bench.mlir.cpu_backend(lower_to_llvm))
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+        assert all(dim % TILE_SIZE == 0 for dim in A.shape), (
+            f"A shape must be multiple of {TILE_SIZE}"
+        )
+        assert all(dim % TILE_SIZE == 0 for dim in B.shape), (
+            f"B shape must be multiple of {TILE_SIZE}"
+        )
+
+        return torch.matmul(A, B)

--- a/infra/scripts/ci-cpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-cpu-run-kernel-bench.sh
@@ -9,9 +9,10 @@ SCRIPTS_DIR=$(realpath $(dirname $0))
 # Backends
 BENCH_BACKEND_TORCH="torch"
 BENCH_BACKEND_TORCH_COMPILE="torch-compile"
+BENCH_BACKEND_MLIR="mlir"
 
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_MLIR})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
   exit 1
@@ -23,7 +24,8 @@ while getopts "b:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
-         [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]; then
+         [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_MLIR}" ]; then
         BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
@@ -54,7 +56,12 @@ git submodule update --init
 pip install --upgrade --user uv
 AI_BENCH_UV=${HOME}/.local/bin/uv
 
-${AI_BENCH_UV} sync --extra cpu --link-mode copy
+PROJECT_DEPS="--extra cpu"
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_MLIR}" ]]; then
+  PROJECT_DEPS="${PROJECT_DEPS} --extra mlir"
+fi
+
+${AI_BENCH_UV} sync ${PROJECT_DEPS} --link-mode copy
 echo ""
 
 # Run benchmark
@@ -64,6 +71,9 @@ BENCH_FLAGS="--bench --gflops"
 
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"
+fi
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_MLIR}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --mlir"
 fi
 
 ${AI_BENCH_UV} run ai-bench ${BENCH_FLAGS}

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -14,9 +14,14 @@ ci:
 
 bench-cpu:
   - params: [A, B]
+    dtype: float32
+    dims:
+      N: 1024
+    flop: "2*N*N*N"
+  - params: [A, B]
     dtype: bfloat16
     dims:
-      N: 256
+      N: 1024
     flop: "2*N*N*N"
 
 bench-gpu:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ xpu = [
   "pytorch-triton-xpu",
   "helion==0.2.9",
 ]
+mlir = [
+  "lighthouse[ingress_torch_mlir]",
+  "ml_dtypes",
+]
 
 [dependency-groups]
 dev = [
@@ -77,6 +81,7 @@ conflicts = [
 [tool.uv.sources]
 torch = { index = "pytorch" }
 pytorch-triton-xpu = { index = "pytorch" }
+lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "d32d1cf" }
 
 [[tool.uv.index]]
 name = "pytorch"
@@ -148,7 +153,9 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-local-folder = ["ai_bench"]
-known-third-party = ["torch", "triton", "helion"]
-known-first-party = ["mlir"]
+known-third-party = [
+  "torch", "triton", "helion",
+  "mlir", "lighthouse", "torch_mlir",
+]
 force-single-line = true  # Improves merge conflicts
 force-sort-within-sections = true

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -21,15 +21,17 @@ class TestBackendEnum:
         assert ai_hc.Backend.PYTORCH_COMPILE == "pytorch-compile"
         assert ai_hc.Backend.TRITON == "triton"
         assert ai_hc.Backend.HELION == "helion"
+        assert ai_hc.Backend.MLIR == "mlir"
 
     def test_backend_iteration(self):
         """Test that all backends can be iterated."""
         backends = list(ai_hc.Backend)
-        assert len(backends) == 4
+        assert len(backends) == 5
         assert ai_hc.Backend.PYTORCH in backends
         assert ai_hc.Backend.PYTORCH_COMPILE in backends
         assert ai_hc.Backend.TRITON in backends
         assert ai_hc.Backend.HELION in backends
+        assert ai_hc.Backend.MLIR in backends
 
     def test_backend_from_string(self):
         """Test creating backend from string."""
@@ -37,6 +39,7 @@ class TestBackendEnum:
         assert ai_hc.Backend("pytorch-compile") == ai_hc.Backend.PYTORCH_COMPILE
         assert ai_hc.Backend("triton") == ai_hc.Backend.TRITON
         assert ai_hc.Backend("helion") == ai_hc.Backend.HELION
+        assert ai_hc.Backend("mlir") == ai_hc.Backend.MLIR
 
     def test_backend_invalid_string(self):
         """Test that invalid string raises error."""
@@ -221,6 +224,20 @@ class TestKernelBenchRunnerInit:
         assert "helion" in str(kb_runner.kernels)
 
     @mock.patch("os.path.isdir")
+    def test_init_mlir_backend(self, mock_isdir):
+        """Test runner initialization with MLIR backend."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            spec_type=ai_hc.SpecKey.V_CI,
+            device=torch.device("cpu"),
+            backend=ai_hc.Backend.MLIR,
+        )
+
+        assert kb_runner.backend == ai_hc.Backend.MLIR
+        assert "mlir" in str(kb_runner.kernels)
+
+    @mock.patch("os.path.isdir")
     def test_init_missing_kernels_dir(self, mock_isdir):
         """Test runner raises error when kernels directory is missing."""
         mock_isdir.return_value = False
@@ -277,11 +294,19 @@ class TestKernelBenchRunnerExecution:
             helion_kernels_dir = (
                 tmpdir / "backends" / "helion" / "KernelBench" / "level1"
             )
+            mlir_cpu_kernels_dir = (
+                tmpdir / "backends" / "mlir" / "cpu" / "KernelBench" / "level1"
+            )
+            mlir_xpu_kernels_dir = (
+                tmpdir / "backends" / "mlir" / "xpu" / "KernelBench" / "level1"
+            )
 
             specs_dir.mkdir(parents=True)
             pytorch_kernels_dir.mkdir(parents=True)
             triton_kernels_dir.mkdir(parents=True)
             helion_kernels_dir.mkdir(parents=True)
+            mlir_cpu_kernels_dir.mkdir(parents=True)
+            mlir_xpu_kernels_dir.mkdir(parents=True)
 
             yield {
                 "root": tmpdir,
@@ -289,6 +314,8 @@ class TestKernelBenchRunnerExecution:
                 "pytorch_kernels": pytorch_kernels_dir,
                 "triton_kernels": triton_kernels_dir,
                 "helion_kernels": helion_kernels_dir,
+                "mlir_cpu_kernels": mlir_cpu_kernels_dir,
+                "mlir_xpu_kernels": mlir_xpu_kernels_dir,
             }
 
     def _create_spec_file(self, specs_dir: Path, filename: str, content: str):
@@ -451,6 +478,18 @@ class Model(torch.nn.Module):
         # Simulated Helion kernel (same result for testing).
         return x @ x
 """
+        mlir_kernel = """
+import torch
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.backend = "mlir"
+
+    def forward(self, x):
+        # Simulated MLIR kernel (same result for testing).
+        return x @ x
+"""
         self._create_spec_file(temp_dirs["specs"], "matmul.yaml", spec_content)
         self._create_kernel_file(
             temp_dirs["pytorch_kernels"], "matmul.py", pytorch_kernel
@@ -460,6 +499,12 @@ class Model(torch.nn.Module):
         )
         self._create_kernel_file(
             temp_dirs["helion_kernels"], "matmul.py", helion_kernel
+        )
+        self._create_kernel_file(
+            temp_dirs["mlir_cpu_kernels"], "matmul.py", mlir_kernel
+        )
+        self._create_kernel_file(
+            temp_dirs["mlir_xpu_kernels"], "matmul.py", mlir_kernel
         )
 
         with mock.patch(
@@ -497,11 +542,29 @@ class Model(torch.nn.Module):
             )
             assert helion_runner.backend == ai_hc.Backend.HELION
 
+            # Run with MLIR backend with CPU.
+            mlir_cpu_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
+            assert mlir_cpu_runner.backend == ai_hc.Backend.MLIR
+
+            # Run with MLIR backend with XPU.
+            mlir_xpu_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("xpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
+            assert mlir_xpu_runner.backend == ai_hc.Backend.MLIR
+
             # Verify they use different kernel directories.
             assert "KernelBench" in str(pytorch_runner.kernels)
             assert "triton" not in str(pytorch_runner.kernels)
             assert "triton" in str(triton_runner.kernels)
             assert "helion" in str(helion_runner.kernels)
+            assert "mlir/cpu" in str(mlir_cpu_runner.kernels)
+            assert "mlir/xpu" in str(mlir_xpu_runner.kernels)
 
     def test_run_kernels_with_inits(self, temp_dirs):
         """Test running kernel that requires initialization parameters."""
@@ -693,11 +756,13 @@ class TestIntegration:
             )
             triton_dir = tmpdir / "backends" / "triton" / "KernelBench" / "level1"
             helion_dir = tmpdir / "backends" / "helion" / "KernelBench" / "level1"
+            mlir_dir = tmpdir / "backends" / "mlir" / "cpu" / "KernelBench" / "level1"
 
             specs_dir.mkdir(parents=True)
             pytorch_dir.mkdir(parents=True)
             triton_dir.mkdir(parents=True)
             helion_dir.mkdir(parents=True)
+            mlir_dir.mkdir(parents=True)
 
             # Create spec.
             spec = """
@@ -768,6 +833,21 @@ class Model(torch.nn.Module):
 '''
             (helion_dir / "matmul.py").write_text(helion_kernel)
 
+            # Create MLIR kernel (mocked - same behavior).
+            mlir_kernel = '''
+import torch
+
+class Model(torch.nn.Module):
+    """Mocked MLIR kernel with same interface."""
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, A, B):
+        # In real usage, this would be a MLIR kernel.
+        return torch.matmul(A, B)
+'''
+            (mlir_dir / "matmul.py").write_text(mlir_kernel)
+
             yield tmpdir
 
     def test_full_ci_pipeline_pytorch(self, integration_setup):
@@ -818,6 +898,18 @@ class Model(torch.nn.Module):
             )
             kb_runner.run_kernels()
 
+    def test_full_ci_pipeline_mlir(self, integration_setup):
+        """Test complete CI pipeline with MLIR backend."""
+        with mock.patch(
+            "ai_bench.utils.finder.project_root", return_value=integration_setup
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
+            kb_runner.run_kernels()
+
     def test_full_bench_pipeline(self, integration_setup):
         """Test complete benchmark pipeline."""
         with mock.patch(
@@ -851,6 +943,11 @@ class Model(torch.nn.Module):
                 device=torch.device("cpu"),
                 backend=ai_hc.Backend.HELION,
             )
+            mlir_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
 
             pytorch_model_cls = pytorch_runner.load_model(
                 integration_setup
@@ -876,10 +973,20 @@ class Model(torch.nn.Module):
                 / "level1"
                 / "matmul.py"
             )
+            mlir_model_cls = mlir_runner.load_model(
+                integration_setup
+                / "backends"
+                / "mlir"
+                / "cpu"
+                / "KernelBench"
+                / "level1"
+                / "matmul.py"
+            )
 
             pytorch_model = pytorch_model_cls()
             triton_model = triton_model_cls()
             helion_model = helion_model_cls()
+            mlir_model = mlir_model_cls()
 
             # Create deterministic inputs.
             torch.manual_seed(42)
@@ -889,9 +996,11 @@ class Model(torch.nn.Module):
             pytorch_result = pytorch_model(A, B)
             triton_result = triton_model(A, B)
             helion_result = helion_model(A, B)
+            mlir_model = mlir_model(A, B)
 
             assert torch.allclose(pytorch_result, triton_result)
             assert torch.allclose(pytorch_result, helion_result)
+            assert torch.allclose(pytorch_result, mlir_model)
 
 
 if __name__ == "__main__":

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -119,6 +119,7 @@ class TestEnvironmentVariables:
             "AIBENCH_KERNELS_DIR",
             "AIBENCH_TRITON_KERNELS_DIR",
             "AIBENCH_HELION_KERNELS_DIR",
+            "AIBENCH_MLIR_KERNELS_DIR",
         ]:
             self._saved_env[key] = os.environ.get(key)
 
@@ -166,6 +167,15 @@ class TestEnvironmentVariables:
         os.environ["AIBENCH_HELION_KERNELS_DIR"] = str(helion_dir)
 
         assert finder.helion_kernels_dir() == helion_dir
+
+    def test_mlir_kernels_from_env_var(self, tmp_path):
+        """Test MLIR kernels path from environment variable."""
+        mlir_dir = tmp_path / "mlir"
+        mlir_dir.mkdir()
+
+        os.environ["AIBENCH_MLIR_KERNELS_DIR"] = str(mlir_dir)
+
+        assert finder.mlir_kernels_dir() == mlir_dir
 
     def test_env_var_nonexistent_path_raises(self, tmp_path):
         """Test that env var with nonexistent path raises error."""


### PR DESCRIPTION
Adds support for executing KernelBench problems with MLIR backend.

The MLIR compilation is achieved through a custom torch.compile backend importing PyTorch models into MLIR IR and using its JIT compilation flow.
The MLIR backend requires users to provide custom lowering logic going from input MLIR to LLVM IR.

The new backend is registered and available through runner scripts and in benchmarking CI job.
Debug MLIR logs can be enabled through new environment variables.