### PR TITLE
[harness] CUDA device

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -27,6 +27,10 @@ on:
         description: "Run on Intel GPU (Helion)"
         type: boolean
         default: false
+      RUN_CUDA_TORCH:
+        description: "Run on Nvidia GPU (PyTorch eager)"
+        type: boolean
+        default: false
 
 env:
   NPROCS_LIMIT_LINK: 8
@@ -104,3 +108,15 @@ jobs:
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
             '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b helion'"
+
+  CUDA-PyTorch:
+    runs-on: pcl-tiergarten
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.RUN_CUDA_TORCH)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Nvidia A100
+        run: "${{ env.SRUN }} --partition=a100 --time=0:15:00 -- \
+            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -b torch'"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@
 [![KernelBench Perf](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml/badge.svg)](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml)
 ![Status](https://img.shields.io/badge/status-beta-yellow)
 
-A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR) and devices (CPU, XPU).
+A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR) and devices (CPU, XPU, CUDA).
+
+| | PyTorch | Triton | Helion | MLIR |
+|:---:|:---:|:---:|:---:|:---:|
+| **CPU** | ✅ | ❌ | ❌ | ✅ |
+| **XPU** | ✅ | ✅ | ✅ | ❌ |
+| **CUDA** | ✅ | ⚠️ | ⚠️ | ❌ |
+
+✅ - Supported ⚠️ - Partially implemented ❌ - Unsupported
 
 ## Installation
 
@@ -25,6 +33,9 @@ uv sync --extra cpu
 
 # CPU + XPU
 uv sync --extra xpu
+
+# CPU + CUDA
+uv sync --extra cuda
 
 # CPU + MLIR backend
 uv sync --extra cpu --extra mlir
@@ -48,6 +59,9 @@ ai-bench --mlir
 
 # PyTorch on XPU
 ai-bench --xpu
+
+# PyTorch on CUDA GPU
+ai-bench --cuda
 
 # PyTorch compile on XPU
 ai-bench --xpu --torch-compile
@@ -153,6 +167,7 @@ Notes legend:
 |--------|-------------|
 | `--kernel KERNEL_PATH SPEC_PATH` | Run a kernel with a spec (default: KernelBench) |
 | `--xpu` | Run on Intel XPU (default: CPU) |
+| `--cuda` | Run on Nvidia GPU (default: CPU) |
 | `--triton` | Use Triton backend (default: PyTorch eager) |
 | `--torch-compile` | Use PyTorch compile mode (default: PyTorch eager) |
 | `--helion` | Use Helion backend (default: PyTorch eager) |

--- a/ai_bench/__init__.py
+++ b/ai_bench/__init__.py
@@ -58,7 +58,7 @@ from ai_bench.harness.runner import MemBwUnit
 # Timing utilities
 from ai_bench.harness.testing import time
 from ai_bench.harness.testing import time_cpu
-from ai_bench.harness.testing import time_xpu
+from ai_bench.harness.testing import time_gpu
 
 # Configuration
 from ai_bench.utils.finder import ConfigurationError
@@ -93,5 +93,5 @@ __all__ = [
     "reset_configuration",
     "time",
     "time_cpu",
-    "time_xpu",
+    "time_gpu",
 ]

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -23,6 +23,9 @@ Examples:
   # Run CI validation on CPU
   ai-bench
 
+  # Run CI validation on CUDA GPU
+  ai-bench --cuda
+
   # Run benchmarks on XPU with PyTorch
   ai-bench --xpu --bench
 
@@ -133,13 +136,14 @@ Environment file (.env) example:
 
     # Device options
     device_group = parser.add_argument_group("device options")
-    device_group.add_argument(
+    device_exclusive = device_group.add_mutually_exclusive_group()
+    device_exclusive.add_argument(
         "--xpu",
         action="store_true",
         default=False,
         help="Run on Intel XPU (default: CPU)",
     )
-    device_group.add_argument(
+    device_exclusive.add_argument(
         "--cuda",
         action="store_true",
         default=False,

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -77,7 +77,7 @@ class KernelRunner:
         if self.is_cpu():
             self.warmup = 5
             self.rep = 20
-        elif self.is_xpu():
+        elif self.is_gpu():
             self.warmup = 200
             self.rep = 100
         else:
@@ -98,6 +98,14 @@ class KernelRunner:
     def is_xpu(self) -> bool:
         """Check if the device is an XPU."""
         return self.device.type == "xpu"
+
+    def is_cuda(self) -> bool:
+        """Check if the device is a CUDA device."""
+        return self.device.type == "cuda"
+
+    def is_gpu(self) -> bool:
+        """Check if the device is a GPU."""
+        return self.is_xpu() or self.is_cuda()
 
     def load_model(self, kernel_path: Path) -> types.ModuleType | None:
         """Load a kernel model.

--- a/ai_bench/harness/testing/__init__.py
+++ b/ai_bench/harness/testing/__init__.py
@@ -1,5 +1,5 @@
 from .timer import time
 from .timer import time_cpu
-from .timer import time_xpu
+from .timer import time_gpu
 
-__all__ = ["time", "time_cpu", "time_xpu"]
+__all__ = ["time", "time_cpu", "time_gpu"]

--- a/ai_bench/harness/testing/timer.py
+++ b/ai_bench/harness/testing/timer.py
@@ -34,13 +34,16 @@ def time_cpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
     return torch.mean(times).item()
 
 
-def time_xpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> float:
-    """Measure execution time of the provided function on XPU.
+def time_gpu(
+    device: torch.device, fn: Callable, args: tuple, warmup: int = 25, rep: int = 100
+) -> float:
+    """Measure execution time of the provided function on GPU.
 
     Uses hardware events for accurate GPU-side timing, with L2 cache flushing
     and a dummy matmul to improve accuracy for short-lived kernels.
 
     Args:
+        device: Target device
         fn: Function to measure
         args: Arguments to pass to the function
         warmup: Warmup iterations
@@ -48,7 +51,10 @@ def time_xpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
     Returns:
         Mean runtime in microseconds
     """
-    device = torch.device("xpu")
+    current_device = torch.accelerator.current_accelerator().type
+    assert current_device == device.type, (
+        f"Invalid accelerator {current_device}, expected {device.type}"
+    )
 
     # Buffer used to flush L2 cache between kernel runs.
     cache_size = 256 * 1024 * 1024
@@ -63,11 +69,11 @@ def time_xpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
     for _ in range(warmup):
         cache.zero_()
         fn(*args)
-    torch.xpu.synchronize()
+    torch.accelerator.synchronize()
 
     # Pre-allocate events to reduce timing overhead.
-    start_events = [torch.xpu.Event(enable_timing=True) for _ in range(rep)]
-    end_events = [torch.xpu.Event(enable_timing=True) for _ in range(rep)]
+    start_events = [torch.Event(device=device, enable_timing=True) for _ in range(rep)]
+    end_events = [torch.Event(device=device, enable_timing=True) for _ in range(rep)]
 
     # Benchmark loop.
     for i in range(rep):
@@ -89,7 +95,7 @@ def time_xpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
         end_events[i].record()
 
     # Ensure all measurements are recorded.
-    torch.xpu.synchronize()
+    torch.accelerator.synchronize()
 
     # Collect times (elapsed_time returns ms, convert to μs).
     times = torch.tensor(
@@ -123,6 +129,6 @@ def time(
     """
     if not device or device.type == "cpu":
         return time_cpu(fn, args, warmup=warmup, rep=rep)
-    if device.type == "xpu":
-        return time_xpu(fn, args, warmup=warmup, rep=rep)
+    if device.type == "xpu" or device.type == "cuda":
+        return time_gpu(device, fn, args, warmup=warmup, rep=rep)
     raise ValueError(f"Unsupported device for timing: {device.type}")

--- a/infra/scripts/ci-cuda-run-kernel-bench.sh
+++ b/infra/scripts/ci-cuda-run-kernel-bench.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Script for CI - CUDA job.
+#
+# Run KernelBench on Nvidia GPU.
+
+SCRIPTS_DIR=$(realpath $(dirname $0))
+
+# Backends
+BENCH_BACKEND_TORCH="torch"
+BENCH_BACKEND_TORCH_COMPILE="torch-compile"
+
+die_syntax() {
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE})]"
+  echo ""
+  echo "  -b: Optional, backend to use (default: torch)"
+  exit 1
+}
+
+# Options
+BENCH_BACKEND=${BENCH_BACKEND_TORCH}
+while getopts "b:" arg; do
+  case ${arg} in
+    b)
+      if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]; then
+        BENCH_BACKEND="${OPTARG}"
+      else
+        echo "Invalid backend: ${OPTARG}"
+        die_syntax
+      fi
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}"
+      die_syntax
+      ;;
+  esac
+done
+
+# Setup
+echo "--- Setup environment"
+source /swtools/cuda/latest/cuda_vars.sh
+echo ""
+
+echo "--- Setup project"
+git submodule update --init
+
+pip install --upgrade --user uv
+AI_BENCH_UV=${HOME}/.local/bin/uv
+
+${AI_BENCH_UV} sync --extra cuda --link-mode copy
+echo ""
+
+# Run benchmark
+echo "--- Run KernelBench (${BENCH_BACKEND})"
+
+BENCH_FLAGS="--cuda --bench"
+
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"
+fi
+
+${AI_BENCH_UV} run ai-bench ${BENCH_FLAGS}
+EXIT_CODE=$?
+
+echo ""
+
+exit ${EXIT_CODE}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,12 @@ xpu = [
   "pytorch-triton-xpu",
   "helion==0.2.9",
 ]
+cuda = [
+  "torch==2.9.1+cu128",
+  "torchvision==0.24.1",
+  "pytorch-triton",
+  "helion==0.2.9",
+]
 mlir = [
   "lighthouse[ingress_torch_mlir]",
   "ml_dtypes",
@@ -75,12 +81,14 @@ conflicts = [
   [
     { extra = "cpu" },
     { extra = "xpu" },
+    { extra = "cuda" },
   ],
 ]
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
 pytorch-triton-xpu = { index = "pytorch" }
+pytorch-triton = { index = "pytorch" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "d32d1cf" }
 
 [[tool.uv.index]]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -273,6 +273,19 @@ class TestKernelBenchRunnerInit:
         assert kb_runner.warmup == 200
         assert kb_runner.rep == 100
 
+    @mock.patch("os.path.isdir")
+    def test_init_cuda_warmup_rep(self, mock_isdir):
+        """Test CUDA warmup and rep settings."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            device=torch.device("cuda"),
+            backend=ai_hc.Backend.PYTORCH,
+        )
+
+        assert kb_runner.warmup == 200
+        assert kb_runner.rep == 100
+
 
 class TestKernelBenchRunnerExecution:
     """Tests for KernelBenchRunner execution with mocked kernels."""
@@ -697,7 +710,7 @@ class TestTimerFunctions:
         x = torch.randn(100)
 
         with pytest.raises(ValueError, match="Unsupported device"):
-            testing.time(simple_fn, (x,), device=torch.device("cuda"))
+            testing.time(simple_fn, (x,), device=torch.device("mps"))
 
 
 class TestEquations:


### PR DESCRIPTION
Adds support for executing on CUDA devices.

PyTorch is supported by default. Triton and Helion should be functional but the full KernelBench execution is not configured yet.