### PR TITLE
Bump PyTorch dependencies

### DIFF
--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 import types
+import warnings
 
 import torch
 import yaml
@@ -193,7 +194,13 @@ class KernelRunner:
             model = model_obj(*model_inits).to(self.device, dtype=model_dtype)
 
             if self.backend == ai_hc.Backend.PYTORCH_COMPILE:
-                model.compile(dynamic=False)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        "`torch.jit.script_method` is deprecated",
+                        category=DeprecationWarning,
+                    )
+                    model.compile(dynamic=False)
 
             # Call model directly to avoid skipping extra hooks if present.
             # It allows 'torch.compile' decorator to be invoked correctly.

--- a/ai_bench/harness/testing/timer.py
+++ b/ai_bench/harness/testing/timer.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+import warnings
 
 import torch
 from torch.profiler import ProfilerActivity
@@ -16,10 +17,17 @@ def time_cpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
     Returns:
         Mean runtime in microseconds
     """
+    # Supress profiler's warning, no event accumulation is needed.
+    warnings.filterwarnings(
+        "ignore",
+        message="Warning: Profiler clears events",
+        category=UserWarning,
+    )
+
     for _ in range(warmup):
         fn(*args)
 
-    with profile(activities=[ProfilerActivity.CPU]) as prof:
+    with profile(activities=[ProfilerActivity.CPU], acc_events=False) as prof:
         for _ in range(rep):
             with record_function("profiled_fn"):
                 fn(*args)

--- a/ai_bench/mlir/compile.py
+++ b/ai_bench/mlir/compile.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 import contextlib
 from dataclasses import dataclass
 import os
+import warnings
 
 from lighthouse import utils as lh_utils
 from lighthouse.ingress.torch import import_from_model
@@ -261,7 +262,8 @@ class MLIRBackend:
 
         # Suppress importer's messages.
         # 'torch_mlir' prints to STDOUT which can be noisy.
-        with contextlib.redirect_stdout(None):
+        with contextlib.redirect_stdout(None), warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
             mlir_mod = import_from_model(
                 model,
                 sample_args=example_inputs,

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -43,7 +43,7 @@ done
 
 # Setup
 echo "--- Setup environment"
-source /swtools/intel/2025.2.0/setvars.sh --force
+source /swtools/intel/setvars.sh
 source /swtools/intel-gpu/latest/intel_gpu_vars.sh
 echo ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,18 +44,18 @@ Repository = "https://github.com/libxsmm/AI-bench"
 
 [project.optional-dependencies]
 cpu = [
-  "torch==2.9.1+cpu",
+  "torch==2.10.0+cpu",
 ]
 xpu = [
-  "torch==2.9.1+xpu",
-  "pytorch-triton-xpu",
-  "helion==0.2.9",
+  "torch==2.10.0+xpu",
+  "triton-xpu",
+  "helion==0.2.10",
 ]
 cuda = [
-  "torch==2.9.1+cu128",
-  "torchvision==0.24.1",
-  "pytorch-triton",
-  "helion==0.2.9",
+  "torch==2.10.0+cu128",
+  "torchvision==0.25.0",
+  "triton",
+  "helion==0.2.10",
 ]
 mlir = [
   "lighthouse[ingress_torch_mlir]",
@@ -87,8 +87,8 @@ conflicts = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-pytorch-triton-xpu = { index = "pytorch" }
-pytorch-triton = { index = "pytorch" }
+triton-xpu = { index = "pytorch" }
+triton = { index = "pytorch" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "d32d1cf" }
 
 [[tool.uv.index]]


### PR DESCRIPTION
Summary:
- bumps torch packages to 2.10.0 versions
- updates triton package name
- bumps helion to 0.2.10
- suppresses new warnings caused by the newer torch version