### PR TITLE
[CLI] ai-bench-compare command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Using `ai-bench-compare` command, KernelBench performance can be compared across
 # Show help
 ai-bench-compare --help
 
-# Default comparison for the given problem on CPU (default)
+# Comparison for the given problem on CPU (default)
 ai-bench-compare --problem level1/1_Square_matrix_multiplication_
 
 # Compare PyTorch and Triton backends on XPU

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml
 ai-bench --kernel /path/to/kernel.py /path/to/spec.yaml --xpu
 ```
 
+Using `ai-bench-compare` command, KernelBench performance can be compared across multiple backends:
+
+```bash
+# Show help
+ai-bench-compare --help
+
+# Default comparison for the given problem on CPU (default)
+ai-bench-compare --problem level1/1_Square_matrix_multiplication_
+
+# Compare PyTorch and Triton backends on XPU
+ai-bench-compare --problem level2/99_Matmul_GELU_Softmax --backend pytorch triton --xpu
+```
+
 Optionally, custom CLI autocompletion is available for certain scripts. It can be activated using:
 ```bash
 activate-global-python-argcomplete --user

--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -41,10 +41,17 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python compare.py --problem level1/23_Softmax --xpu
-  python compare.py --problem level1/23_Softmax --xpu --backends pytorch triton
+  # Run comparison on CPU
+  ai-bench-compare --problem level1/19_ReLU
 
-CV Stability: ★★★ (<1%) | ★★ (1-5%) | ★ (5-10%) | ⚠ (>10%)
+  # Run comparison on XPU
+  ai-bench-compare --problem level1/19_ReLU --xpu
+
+  # Run comparison on CUDA GPU
+  ai-bench-compare --problem level1/19_ReLU --cuda
+
+  # Run comparison between PyTorch and Triton
+  ai-bench-compare --problem level2/99_Matmul_GELU_Softmax --xpu --backends pytorch triton
         """,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 
 [project.scripts]
 ai-bench = "ai_bench.cli:main"
+ai-bench-compare = "ai_bench.cli_compare:main"
 
 [project.urls]
 Homepage = "https://github.com/libxsmm/AI-bench"


### PR DESCRIPTION
Adds 'ai-bench-compare' CLI command for easier access to the performance comparison tool.

The 'compare.py' script used for comparison is converted into a submodule and exposed as a CLI command.