### PR TITLE
Per-problem tolerance configuration for correctness checks [1/2]

### DIFF
--- a/ai_bench/__init__.py
+++ b/ai_bench/__init__.py
@@ -40,10 +40,12 @@ from ai_bench.harness.core import SpecKey
 from ai_bench.harness.core import VKey
 
 # Core functions
+from ai_bench.harness.core import get_atol
 from ai_bench.harness.core import get_flop
 from ai_bench.harness.core import get_inits
 from ai_bench.harness.core import get_inputs
 from ai_bench.harness.core import get_mem_bytes
+from ai_bench.harness.core import get_rtol
 from ai_bench.harness.core import get_torch_dtype
 from ai_bench.harness.core import get_variant_torch_dtype
 from ai_bench.harness.core import input_shape
@@ -80,10 +82,12 @@ __all__ = [
     "VKey",
     "__version__",
     "configure",
+    "get_atol",
     "get_flop",
     "get_inits",
     "get_inputs",
     "get_mem_bytes",
+    "get_rtol",
     "get_torch_dtype",
     "get_variant_torch_dtype",
     "input_shape",

--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -52,6 +52,9 @@ Examples:
 
   # Run comparison between PyTorch and Triton
   ai-bench-compare --problem level2/99_Matmul_GELU_Softmax --xpu --backends pytorch triton
+
+  # Override tolerances from command line (takes priority over spec values)
+  ai-bench-compare --problem level1/19_ReLU --xpu --rtol 1e-3 --atol 1e-6
         """,
     )
 
@@ -80,8 +83,18 @@ Examples:
     )
 
     bench_group = parser.add_argument_group("kernel validation options")
-    bench_group.add_argument("--rtol", default=1e-2, type=float)
-    bench_group.add_argument("--atol", default=1e-5, type=float)
+    bench_group.add_argument(
+        "--rtol",
+        default=None,
+        type=float,
+        help="Override relative tolerance (default: per-problem spec value, fallback 1e-2)",
+    )
+    bench_group.add_argument(
+        "--atol",
+        default=None,
+        type=float,
+        help="Override absolute tolerance (default: per-problem spec value, fallback 1e-5)",
+    )
 
     # TODO: Enable and propagate config.
     # bench_group = parser.add_argument_group("benchmarking options")

--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -6,10 +6,12 @@ from .specs import InKey
 from .specs import SpecKey
 from .specs import VKey
 from .specs import apply_input_inits
+from .specs import get_atol
 from .specs import get_flop
 from .specs import get_inits
 from .specs import get_inputs
 from .specs import get_mem_bytes
+from .specs import get_rtol
 from .specs import get_torch_dtype
 from .specs import get_variant_torch_dtype
 from .specs import input_is_bool
@@ -28,10 +30,12 @@ __all__ = [
     "SpecKey",
     "VKey",
     "apply_input_inits",
+    "get_atol",
     "get_flop",
     "get_inits",
     "get_inputs",
     "get_mem_bytes",
+    "get_rtol",
     "get_torch_dtype",
     "get_variant_torch_dtype",
     "input_is_bool",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -65,6 +65,8 @@ class VKey(StrEnum):
     DIMS = "dims"
     FLOP = "flop"
     MEM_BYTES = "mem_bytes"
+    RTOL = "rtol"
+    ATOL = "atol"
 
 
 class Backend(StrEnum):
@@ -75,6 +77,11 @@ class Backend(StrEnum):
     TRITON = "triton"
     HELION = "helion"
     MLIR = "mlir"
+
+
+# Default tolerance values (match current hardcoded behavior).
+_DEFAULT_RTOL = 1e-2
+_DEFAULT_ATOL = 1e-5
 
 
 def input_shape(input_entry: dict, dims: Dict[str, int]) -> list[int]:
@@ -348,3 +355,29 @@ def get_mem_bytes(variant: dict) -> float | None:
         Number of bytes if available
     """
     return _eval_variant_formula(variant, VKey.MEM_BYTES)
+
+
+def get_rtol(variant: dict) -> float:
+    """Get relative tolerance for correctness checks.
+
+    Falls back to default (1e-2) when not specified in the spec.
+
+    Args:
+        variant: Specs' variant entry
+    Returns:
+        Relative tolerance value
+    """
+    return variant.get(VKey.RTOL, _DEFAULT_RTOL)
+
+
+def get_atol(variant: dict) -> float:
+    """Get absolute tolerance for correctness checks.
+
+    Falls back to default (1e-5) when not specified in the spec.
+
+    Args:
+        variant: Specs' variant entry
+    Returns:
+        Absolute tolerance value
+    """
+    return variant.get(VKey.ATOL, _DEFAULT_ATOL)

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -103,6 +103,8 @@ def check_correctness(original_output, optimized_output, rtol, atol) -> bool:
     Args:
         original_output: Output from original kernel
         optimized_output: Output from optimized kernel
+        rtol: Relative tolerance
+        atol: Absolute tolerance
 
     Returns:
         True if outputs match within tolerance
@@ -189,11 +191,27 @@ def benchmark_problem(
     problem: str,
     device: torch.device,
     spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_BENCH_GPU,
-    rtol: float = 1e-2,
-    atol: float = 1e-5,
+    rtol: float | None = None,
+    atol: float | None = None,
     backends: Optional[List[ai_hc.Backend]] = None,
 ) -> dict:
-    """Benchmark a specific problem across multiple backends."""
+    """Benchmark a specific problem across multiple backends.
+
+    Tolerance resolution order (highest priority first):
+        1. Explicit rtol/atol arguments (CLI override)
+        2. Per-variant spec values (rtol/atol in YAML)
+        3. Default values (1e-2 / 1e-5)
+
+    Args:
+        problem: Problem identifier in 'level/kernel_name' format
+        device: Target device
+        spec_type: Type of problem spec to use
+        rtol: Override relative tolerance. If None, uses per-variant spec value.
+        atol: Override absolute tolerance. If None, uses per-variant spec value.
+        backends: List of backends to benchmark
+    Returns:
+        Dictionary with benchmark results
+    """
     if backends is None:
         backends = [
             ai_hc.Backend.PYTORCH,
@@ -291,15 +309,31 @@ def benchmark_problem(
                         cur_fn = model.forward
                         cur_output = cur_fn(*inputs_cur)
 
+                    # Resolve tolerances: CLI override > spec value > default
+                    effective_rtol = (
+                        rtol
+                        if rtol is not None
+                        else ai_hc.get_rtol(variants[variant_idx])
+                    )
+                    effective_atol = (
+                        atol
+                        if atol is not None
+                        else ai_hc.get_atol(variants[variant_idx])
+                    )
+
                     #  Compare outputs
-                    correct = check_correctness(pytorch_output, cur_output, rtol, atol)
+                    correct = check_correctness(
+                        pytorch_output, cur_output, effective_rtol, effective_atol
+                    )
                     if correct:
                         logger.info(
-                            f"\033[92m✔\033[0m  Correctness check PASSED for {backend} !"
+                            f"\033[92m✔\033[0m  Correctness check PASSED for {backend} "
+                            f"(rtol={effective_rtol:.1e}, atol={effective_atol:.1e})"
                         )
                     else:
                         logger.warning(
-                            f"\033[91m✘\033[0m  Correctness check FAILED for {backend} !"
+                            f"\033[91m✘\033[0m  Correctness check FAILED for {backend} "
+                            f"(rtol={effective_rtol:.1e}, atol={effective_atol:.1e})"
                         )
 
                 # benchmark

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -1,0 +1,283 @@
+"""Tests for per-problem tolerance configuration."""
+
+import pytest
+import torch
+
+from ai_bench.harness import core as ai_hc
+
+
+class TestToleranceVKey:
+    """Tests for VKey tolerance entries."""
+
+    def test_vkey_has_rtol(self):
+        """Test VKey enum includes rtol."""
+        assert ai_hc.VKey.RTOL == "rtol"
+
+    def test_vkey_has_atol(self):
+        """Test VKey enum includes atol."""
+        assert ai_hc.VKey.ATOL == "atol"
+
+    def test_vkey_iteration_includes_tolerances(self):
+        """Test that tolerance keys are included in VKey iteration."""
+        all_keys = list(ai_hc.VKey)
+        assert ai_hc.VKey.RTOL in all_keys
+        assert ai_hc.VKey.ATOL in all_keys
+
+
+class TestGetRtol:
+    """Tests for get_rtol function."""
+
+    def test_rtol_from_variant(self):
+        """Test rtol extraction when specified in variant."""
+        variant = {
+            ai_hc.VKey.DIMS: {"M": 64},
+            ai_hc.VKey.RTOL: 1e-3,
+        }
+        assert ai_hc.get_rtol(variant) == 1e-3
+
+    def test_rtol_default_when_missing(self):
+        """Test rtol falls back to default when not in variant."""
+        variant = {ai_hc.VKey.DIMS: {"M": 64}}
+        assert ai_hc.get_rtol(variant) == 1e-2
+
+    def test_rtol_zero(self):
+        """Test rtol can be set to zero (exact match)."""
+        variant = {ai_hc.VKey.RTOL: 0.0}
+        assert ai_hc.get_rtol(variant) == 0.0
+
+    def test_rtol_large_value(self):
+        """Test rtol with large tolerance (e.g., for low-precision dtypes)."""
+        variant = {ai_hc.VKey.RTOL: 0.5}
+        assert ai_hc.get_rtol(variant) == 0.5
+
+
+class TestGetAtol:
+    """Tests for get_atol function."""
+
+    def test_atol_from_variant(self):
+        """Test atol extraction when specified in variant."""
+        variant = {
+            ai_hc.VKey.DIMS: {"M": 64},
+            ai_hc.VKey.ATOL: 1e-6,
+        }
+        assert ai_hc.get_atol(variant) == 1e-6
+
+    def test_atol_default_when_missing(self):
+        """Test atol falls back to default when not in variant."""
+        variant = {ai_hc.VKey.DIMS: {"M": 64}}
+        assert ai_hc.get_atol(variant) == 1e-5
+
+    def test_atol_zero(self):
+        """Test atol can be set to zero."""
+        variant = {ai_hc.VKey.ATOL: 0.0}
+        assert ai_hc.get_atol(variant) == 0.0
+
+    def test_atol_large_value(self):
+        """Test atol with large tolerance."""
+        variant = {ai_hc.VKey.ATOL: 1e-1}
+        assert ai_hc.get_atol(variant) == 1e-1
+
+
+class TestTolerancesPerDtype:
+    """Tests for per-dtype tolerance differentiation."""
+
+    def test_different_tolerances_per_dtype_variant(self):
+        """Test different tolerances for float32 vs float16 variants."""
+        variant_fp32 = {
+            ai_hc.VKey.PARAMS: ["A", "B"],
+            ai_hc.VKey.DIMS: {"M": 4096, "N": 4096, "K": 4096},
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.FLOP: "2*M*N*K",
+            ai_hc.VKey.RTOL: 1e-5,
+            ai_hc.VKey.ATOL: 1e-8,
+        }
+        variant_fp16 = {
+            ai_hc.VKey.PARAMS: ["A", "B"],
+            ai_hc.VKey.DIMS: {"M": 4096, "N": 4096, "K": 4096},
+            ai_hc.VKey.TYPE: "float16",
+            ai_hc.VKey.FLOP: "2*M*N*K",
+            ai_hc.VKey.RTOL: 1e-1,
+            ai_hc.VKey.ATOL: 1e-2,
+        }
+
+        # float32 should be tighter
+        assert ai_hc.get_rtol(variant_fp32) == 1e-5
+        assert ai_hc.get_atol(variant_fp32) == 1e-8
+
+        # float16 should be more relaxed
+        assert ai_hc.get_rtol(variant_fp16) == 1e-1
+        assert ai_hc.get_atol(variant_fp16) == 1e-2
+
+    def test_mixed_tolerance_spec(self):
+        """Test variant with rtol but no atol uses atol default."""
+        variant = {
+            ai_hc.VKey.DIMS: {"N": 64},
+            ai_hc.VKey.RTOL: 5e-3,
+            # atol intentionally missing
+        }
+        assert ai_hc.get_rtol(variant) == 5e-3
+        assert ai_hc.get_atol(variant) == 1e-5  # default
+
+    def test_mixed_tolerance_spec_reverse(self):
+        """Test variant with atol but no rtol uses rtol default."""
+        variant = {
+            ai_hc.VKey.DIMS: {"N": 64},
+            # rtol intentionally missing
+            ai_hc.VKey.ATOL: 1e-7,
+        }
+        assert ai_hc.get_rtol(variant) == 1e-2  # default
+        assert ai_hc.get_atol(variant) == 1e-7
+
+
+class TestBackwardCompatibility:
+    """Tests ensuring backward compatibility with existing specs."""
+
+    def test_no_tolerance_fields_uses_defaults(self):
+        """Test that specs without rtol/atol still work with defaults."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["A", "B"],
+            ai_hc.VKey.DIMS: {"M": 32, "N": 32, "K": 32},
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.FLOP: "2*M*N*K",
+            ai_hc.VKey.MEM_BYTES: "(M*K + K*N + M*N) * 4",
+        }
+
+        assert ai_hc.get_rtol(variant) == 1e-2
+        assert ai_hc.get_atol(variant) == 1e-5
+
+    def test_existing_functions_unaffected(self):
+        """Test that existing VKey functions still work alongside tolerance."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"N": 128},
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.FLOP: "2*N",
+            ai_hc.VKey.MEM_BYTES: "N*4",
+            ai_hc.VKey.RTOL: 1e-3,
+            ai_hc.VKey.ATOL: 1e-6,
+        }
+
+        # Existing functions should work unchanged
+        assert ai_hc.get_flop(variant) == 256
+        assert ai_hc.get_mem_bytes(variant) == 512
+        assert ai_hc.get_variant_torch_dtype(variant) == torch.float32
+
+        # New tolerance functions should also work
+        assert ai_hc.get_rtol(variant) == 1e-3
+        assert ai_hc.get_atol(variant) == 1e-6
+
+    def test_empty_variant_defaults(self):
+        """Test that minimal variant returns defaults."""
+        variant = {}
+        assert ai_hc.get_rtol(variant) == 1e-2
+        assert ai_hc.get_atol(variant) == 1e-5
+
+
+class TestYamlRoundTrip:
+    """Tests for YAML serialization/deserialization of tolerances."""
+
+    def test_tolerance_survives_yaml_roundtrip(self, tmp_path):
+        """Test tolerances survive YAML write and read."""
+        import yaml
+
+        spec = {
+            "inputs": {
+                "X": {"shape": ["N"], "dtype": "float32"},
+            },
+            "bench-gpu": [
+                {
+                    "params": ["X"],
+                    "dims": {"N": 1024},
+                    "dtype": "float32",
+                    "flop": "2*N",
+                    "rtol": 1e-3,
+                    "atol": 1e-6,
+                },
+                {
+                    "params": ["X"],
+                    "dims": {"N": 1024},
+                    "dtype": "float16",
+                    "flop": "2*N",
+                    "rtol": 5e-2,
+                    "atol": 1e-3,
+                },
+            ],
+        }
+
+        spec_path = tmp_path / "test_spec.yaml"
+        with open(spec_path, "w") as f:
+            yaml.dump(spec, f, default_flow_style=False)
+
+        with open(spec_path) as f:
+            loaded = yaml.safe_load(f)
+
+        variants = loaded["bench-gpu"]
+
+        # float32 variant
+        assert ai_hc.get_rtol(variants[0]) == 1e-3
+        assert ai_hc.get_atol(variants[0]) == 1e-6
+
+        # float16 variant
+        assert ai_hc.get_rtol(variants[1]) == 5e-2
+        assert ai_hc.get_atol(variants[1]) == 1e-3
+
+    def test_missing_tolerance_in_yaml(self, tmp_path):
+        """Test YAML spec without tolerance fields returns defaults."""
+        import yaml
+
+        spec = {
+            "inputs": {
+                "A": {"shape": ["N", "N"], "dtype": "float32"},
+            },
+            "bench-gpu": [
+                {
+                    "params": ["A"],
+                    "dims": {"N": 512},
+                    "dtype": "float32",
+                    "flop": "2*N*N*N",
+                },
+            ],
+        }
+
+        spec_path = tmp_path / "no_tol_spec.yaml"
+        with open(spec_path, "w") as f:
+            yaml.dump(spec, f, default_flow_style=False)
+
+        with open(spec_path) as f:
+            loaded = yaml.safe_load(f)
+
+        variant = loaded["bench-gpu"][0]
+        assert ai_hc.get_rtol(variant) == 1e-2
+        assert ai_hc.get_atol(variant) == 1e-5
+
+    def test_partial_tolerance_in_yaml(self, tmp_path):
+        """Test YAML spec with only rtol specified."""
+        import yaml
+
+        spec = {
+            "inputs": {
+                "X": {"shape": ["N"], "dtype": "float32"},
+            },
+            "ci": [
+                {
+                    "params": ["X"],
+                    "dims": {"N": 8},
+                    "rtol": 1e-4,
+                },
+            ],
+        }
+
+        spec_path = tmp_path / "partial_tol_spec.yaml"
+        with open(spec_path, "w") as f:
+            yaml.dump(spec, f, default_flow_style=False)
+
+        with open(spec_path) as f:
+            loaded = yaml.safe_load(f)
+
+        variant = loaded["ci"][0]
+        assert ai_hc.get_rtol(variant) == 1e-4
+        assert ai_hc.get_atol(variant) == 1e-5  # default
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Correctness checks in benchmark_compare use hardcoded rtol=1e-2 / atol=1e-5 for all problems. Different kernels and dtypes need different tolerances - e.g., float16 matmul needs much looser bounds than float32 element-wise ops. 

Add rtol and atol as optional fields on YAML spec variants, following the same pattern as flop and mem_bytes.
```yaml

bench-gpu:
  - params: [A, B]
    dims: { M: 4096, N: 4096, K: 4096 }
    dtype: float32
    rtol: 1e-2
    atol: 1e-5
  - params: [A, B]
    dims: { M: 4096, N: 4096, K: 4096 }
    dtype: float16
    rtol: 1e-1
    atol: 1e-3
```
Tolerance resolution priority: CLI --rtol/--atol override → spec value → default (1e-2 / 1e-5).
I will patch yaml files in separate PR. 