### PR TITLE
[CI] KernelBench run mode

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -3,6 +3,13 @@ name: KernelBench Perf
 on:
   workflow_dispatch:
     inputs:
+      RUN_MODE:
+        description: "Run mode"
+        type: choice
+        default: 'bench'
+        options:
+          - bench
+          - ci
       DEVICE_CPU:
         description: "Device: CPU"
         type: boolean
@@ -51,7 +58,7 @@ jobs:
 
       - name: Intel Emerald Rapids
         run: "${{ env.SRUN }} --partition=emr --time=0:15:00 --constraint=\"notrb\" -- \
-            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -b torch'"
+            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b torch'"
 
   CPU-MLIR:
     runs-on: pcl-tiergarten
@@ -63,7 +70,7 @@ jobs:
 
       - name: Intel Emerald Rapids
         run: "${{ env.SRUN }} --partition=emr --time=0:15:00 --constraint=\"notrb\" -- \
-            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -b mlir'"
+            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b mlir'"
 
   XPU-PyTorch:
     runs-on: pcl-tiergarten
@@ -75,7 +82,7 @@ jobs:
 
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b torch'"
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b torch'"
 
   XPU-PyTorch-Compile:
     runs-on: pcl-tiergarten
@@ -87,7 +94,7 @@ jobs:
 
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b torch-compile'"
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b torch-compile'"
 
   XPU-Triton:
     runs-on: pcl-tiergarten
@@ -99,7 +106,7 @@ jobs:
 
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b triton'"
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b triton'"
 
   XPU-Helion:
     runs-on: pcl-tiergarten
@@ -111,7 +118,7 @@ jobs:
 
       - name: Intel Arc B580
         run: "${{ env.SRUN }} --partition=b580 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -b helion'"
+            '${{ github.workspace }}/infra/scripts/ci-xpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b helion'"
 
   CUDA-PyTorch:
     runs-on: pcl-tiergarten
@@ -123,7 +130,7 @@ jobs:
 
       - name: Nvidia A100
         run: "${{ env.SRUN }} --partition=a100 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -b torch'"
+            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b torch'"
 
   CUDA-Triton:
     runs-on: pcl-tiergarten
@@ -135,7 +142,7 @@ jobs:
 
       - name: Nvidia A100
         run: "${{ env.SRUN }} --partition=a100 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -b triton'"
+            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b triton'"
 
   CUDA-Helion:
     runs-on: pcl-tiergarten
@@ -147,4 +154,4 @@ jobs:
 
       - name: Nvidia A100
         run: "${{ env.SRUN }} --partition=a100 --time=0:15:00 -- \
-            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -b helion'"
+            '${{ github.workspace }}/infra/scripts/ci-cuda-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b helion'"

--- a/infra/scripts/ci-cpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-cpu-run-kernel-bench.sh
@@ -11,16 +11,23 @@ BENCH_BACKEND_TORCH="torch"
 BENCH_BACKEND_TORCH_COMPILE="torch-compile"
 BENCH_BACKEND_MLIR="mlir"
 
+# Run modes
+RUN_MODE_BENCH="bench"
+RUN_MODE_CI="ci"
+
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_MLIR})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_MLIR})] [-m (${RUN_MODE_BENCH}|${RUN_MODE_CI})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
+  echo "  -m: Optional, run mode to use (default: bench)"
   exit 1
 }
 
 # Options
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
-while getopts "b:" arg; do
+RUN_MODE=${RUN_MODE_BENCH}
+
+while getopts "bm:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
@@ -29,6 +36,15 @@ while getopts "b:" arg; do
         BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
+        die_syntax
+      fi
+      ;;
+    m)
+      if [ "${OPTARG}" == "${RUN_MODE_BENCH}" ] || \
+         [ "${OPTARG}" == "${RUN_MODE_CI}" ]; then
+        RUN_MODE="${OPTARG}"
+      else
+        echo "Invalid run mode: ${OPTARG}"
         die_syntax
       fi
       ;;
@@ -67,7 +83,11 @@ echo ""
 # Run benchmark
 echo "--- Run KernelBench (${BENCH_BACKEND})"
 
-BENCH_FLAGS="--bench --gflops"
+BENCH_FLAGS="--gflops"
+
+if [[ "${RUN_MODE}" == "${RUN_MODE_BENCH}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --bench"
+fi
 
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"

--- a/infra/scripts/ci-cpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-cpu-run-kernel-bench.sh
@@ -27,7 +27,7 @@ die_syntax() {
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
 RUN_MODE=${RUN_MODE_BENCH}
 
-while getopts "bm:" arg; do
+while getopts "b:m:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \

--- a/infra/scripts/ci-cuda-run-kernel-bench.sh
+++ b/infra/scripts/ci-cuda-run-kernel-bench.sh
@@ -12,16 +12,24 @@ BENCH_BACKEND_TORCH_COMPILE="torch-compile"
 BENCH_BACKEND_TRITON="triton"
 BENCH_BACKEND_HELION="helion"
 
+# Run modes
+RUN_MODE_BENCH="bench"
+RUN_MODE_CI="ci"
+
+
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_HELION})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_HELION})] [-m (${RUN_MODE_BENCH}|${RUN_MODE_CI})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
+  echo "  -m: Optional, run mode to use (default: bench)"
   exit 1
 }
 
 # Options
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
-while getopts "b:" arg; do
+RUN_MODE=${RUN_MODE_BENCH}
+
+while getopts "bm:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
@@ -31,6 +39,15 @@ while getopts "b:" arg; do
         BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
+        die_syntax
+      fi
+      ;;
+    m)
+      if [ "${OPTARG}" == "${RUN_MODE_BENCH}" ] || \
+         [ "${OPTARG}" == "${RUN_MODE_CI}" ]; then
+        RUN_MODE="${OPTARG}"
+      else
+        echo "Invalid run mode: ${OPTARG}"
         die_syntax
       fi
       ;;
@@ -58,7 +75,11 @@ echo ""
 # Run benchmark
 echo "--- Run KernelBench (${BENCH_BACKEND})"
 
-BENCH_FLAGS="--cuda --bench"
+BENCH_FLAGS="--cuda"
+
+if [[ "${RUN_MODE}" == "${RUN_MODE_BENCH}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --bench"
+fi
 
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"

--- a/infra/scripts/ci-cuda-run-kernel-bench.sh
+++ b/infra/scripts/ci-cuda-run-kernel-bench.sh
@@ -29,7 +29,7 @@ die_syntax() {
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
 RUN_MODE=${RUN_MODE_BENCH}
 
-while getopts "bm:" arg; do
+while getopts "b:m:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -12,16 +12,23 @@ BENCH_BACKEND_TORCH_COMPILE="torch-compile"
 BENCH_BACKEND_TRITON="triton"
 BENCH_BACKEND_HELION="helion"
 
+# Run modes
+RUN_MODE_BENCH="bench"
+RUN_MODE_CI="ci"
+
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_HELION})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_HELION})] [-m (${RUN_MODE_BENCH}|${RUN_MODE_CI})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
+  echo "  -m: Optional, run mode to use (default: bench)"
   exit 1
 }
 
 # Options
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
-while getopts "b:" arg; do
+RUN_MODE=${RUN_MODE_BENCH}
+
+while getopts "bm:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
@@ -31,6 +38,15 @@ while getopts "b:" arg; do
         BENCH_BACKEND="${OPTARG}"
       else
         echo "Invalid backend: ${OPTARG}"
+        die_syntax
+      fi
+      ;;
+    m)
+      if [ "${OPTARG}" == "${RUN_MODE_BENCH}" ] || \
+         [ "${OPTARG}" == "${RUN_MODE_CI}" ]; then
+        RUN_MODE="${OPTARG}"
+      else
+        echo "Invalid run mode: ${OPTARG}"
         die_syntax
       fi
       ;;
@@ -59,7 +75,11 @@ echo ""
 # Run benchmark
 echo "--- Run KernelBench (${BENCH_BACKEND})"
 
-BENCH_FLAGS="--xpu --bench"
+BENCH_FLAGS="--xpu"
+
+if [[ "${RUN_MODE}" == "${RUN_MODE_BENCH}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --bench"
+fi
 
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -28,7 +28,7 @@ die_syntax() {
 BENCH_BACKEND=${BENCH_BACKEND_TORCH}
 RUN_MODE=${RUN_MODE_BENCH}
 
-while getopts "bm:" arg; do
+while getopts "b:m:" arg; do
   case ${arg} in
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \


### PR DESCRIPTION
Adds selector for ai-bench run mode which allows running through KernelBench problems using CI variant.

The addition allows to easily dispatch test runs for various optional backend and device combinations.