### PR TITLE
Add --channels-last and --variant flags to ai-bench-compare

### DIFF
--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -106,11 +106,6 @@ Examples:
 
     parser.add_argument("--brief", action="store_true", help="Brief output")
     parser.add_argument(
-        "--channels-last",
-        action="store_true",
-        help="Use channels_last memory format for 4D tensors (NCHW → NHWC)",
-    )
-    parser.add_argument(
         "--variant",
         type=str,
         default=None,
@@ -153,7 +148,6 @@ Examples:
             rtol=args.rtol,
             atol=args.atol,
             backends=backends,
-            channels_last=args.channels_last,
         )
         (print_comparison_brief if args.brief else print_comparison)(results)
         return 0

--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -105,6 +105,17 @@ Examples:
     # bench_group.add_argument("--no-clear-l2", action="store_true")
 
     parser.add_argument("--brief", action="store_true", help="Brief output")
+    parser.add_argument(
+        "--channels-last",
+        action="store_true",
+        help="Use channels_last memory format for 4D tensors (NCHW → NHWC)",
+    )
+    parser.add_argument(
+        "--variant",
+        type=str,
+        default=None,
+        help="Variant name from spec (e.g. bench-gpu-1). Overrides default spec_type selection.",
+    )
 
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
@@ -123,7 +134,9 @@ Examples:
         device = torch.device("cpu")
 
     # Determine spec type
-    if args.ci:
+    if args.variant:
+        spec_type = args.variant
+    elif args.ci:
         spec_type = ai_hc.SpecKey.V_CI
     else:
         spec_type = (
@@ -140,6 +153,7 @@ Examples:
             rtol=args.rtol,
             atol=args.atol,
             backends=backends,
+            channels_last=args.channels_last,
         )
         (print_comparison_brief if args.brief else print_comparison)(results)
         return 0

--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -13,6 +13,7 @@ from .specs import get_inputs
 from .specs import get_mem_bytes
 from .specs import get_rtol
 from .specs import get_torch_dtype
+from .specs import get_variant_memory_format
 from .specs import get_variant_torch_dtype
 from .specs import input_is_bool
 from .specs import input_is_float
@@ -37,6 +38,7 @@ __all__ = [
     "get_mem_bytes",
     "get_rtol",
     "get_torch_dtype",
+    "get_variant_memory_format",
     "get_variant_torch_dtype",
     "input_is_bool",
     "input_is_float",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -239,13 +239,17 @@ def _get_logger():
 
 
 def get_inputs(
-    variant: dict, inputs: dict, device: torch.device | None = None
+    variant: dict,
+    inputs: dict,
+    device: torch.device | None = None,
+    channels_last: bool = False,
 ) -> list[torch.Tensor]:
     """Get torch tensors for given specs' config.
     Args:
         variant: Specs' variant entry
         inputs: Specs' inputs entry
         device: Desired device of the tensors
+        channels_last: If True, convert 4D/5D tensors to channels_last memory format
     Returns:
         list of torch tensors
     """
@@ -279,6 +283,11 @@ def get_inputs(
 
         if InKey.INITS in input_entry:
             tensor = apply_input_inits(tensor, input_entry[InKey.INITS])
+
+        if channels_last and tensor.ndim == 4:
+            tensor = tensor.to(memory_format=torch.channels_last)
+        elif channels_last and tensor.ndim == 5:
+            tensor = tensor.to(memory_format=torch.channels_last_3d)
 
         vals.append(tensor)
     return vals

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -62,6 +62,7 @@ class VKey(StrEnum):
 
     PARAMS = "params"
     TYPE = "dtype"
+    MEMORY_FORMAT = "memory_format"
     DIMS = "dims"
     FLOP = "flop"
     MEM_BYTES = "mem_bytes"
@@ -242,14 +243,12 @@ def get_inputs(
     variant: dict,
     inputs: dict,
     device: torch.device | None = None,
-    channels_last: bool = False,
 ) -> list[torch.Tensor]:
     """Get torch tensors for given specs' config.
     Args:
         variant: Specs' variant entry
         inputs: Specs' inputs entry
         device: Desired device of the tensors
-        channels_last: If True, convert 4D/5D tensors to channels_last memory format
     Returns:
         list of torch tensors
     """
@@ -284,10 +283,11 @@ def get_inputs(
         if InKey.INITS in input_entry:
             tensor = apply_input_inits(tensor, input_entry[InKey.INITS])
 
-        if channels_last and tensor.ndim == 4:
-            tensor = tensor.to(memory_format=torch.channels_last)
-        elif channels_last and tensor.ndim == 5:
-            tensor = tensor.to(memory_format=torch.channels_last_3d)
+        memory_format = get_variant_memory_format(variant)
+        if memory_format is not None:
+            expected_ndim = 5 if memory_format == torch.channels_last_3d else 4
+            if tensor.ndim == expected_ndim:
+                tensor = tensor.to(memory_format=memory_format)
 
         vals.append(tensor)
     return vals
@@ -321,6 +321,25 @@ def get_variant_torch_dtype(variant: dict) -> torch.dtype | None:
     if VKey.TYPE not in variant:
         return None
     return get_torch_dtype(variant[VKey.TYPE])
+
+
+def get_variant_memory_format(variant: dict) -> torch.memory_format | None:
+    """Get torch memory format for given specs' variant.
+    Args:
+        variant: Specs' variant entry
+    Returns:
+        torch memory format if available
+    """
+    if VKey.MEMORY_FORMAT not in variant:
+        return None
+    fmt_str = variant[VKey.MEMORY_FORMAT]
+    fmt = getattr(torch, fmt_str, None)
+    if not isinstance(fmt, torch.memory_format):
+        raise ValueError(
+            f"Invalid memory_format '{fmt_str}'. "
+            f"Expected 'channels_last' or 'channels_last_3d'."
+        )
+    return fmt
 
 
 def _eval_variant_formula(variant: dict, key: VKey) -> float | None:

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -190,10 +190,11 @@ class VariantResult:
 def benchmark_problem(
     problem: str,
     device: torch.device,
-    spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_BENCH_GPU,
+    spec_type: str = ai_hc.SpecKey.V_BENCH_GPU,
     rtol: float | None = None,
     atol: float | None = None,
     backends: Optional[List[ai_hc.Backend]] = None,
+    channels_last: bool = False,
 ) -> dict:
     """Benchmark a specific problem across multiple backends.
 
@@ -278,7 +279,9 @@ def benchmark_problem(
                 )
                 logger.info(f"Variant: {variants[variant_idx]}")
 
-                model = runner.init_model(model_obj, variants[variant_idx], inits)
+                model = runner.init_model(
+                    model_obj, variants[variant_idx], inits, channels_last=channels_last
+                )
                 if backend == str(ai_hc.Backend.PYTORCH_COMPILE):
                     model.compile(dynamic=False)
                 # save pytorch model for correctness check
@@ -287,7 +290,10 @@ def benchmark_problem(
 
                 # prepare inputs
                 inputs = ai_hc.get_inputs(
-                    variants[variant_idx], spec_inputs, device=runner.device
+                    variants[variant_idx],
+                    spec_inputs,
+                    device=runner.device,
+                    channels_last=channels_last,
                 )
 
                 # correctness check, only if we have a reference PyTorch model and we're not currently benchmarking the PyTorch backend

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -194,7 +194,6 @@ def benchmark_problem(
     rtol: float | None = None,
     atol: float | None = None,
     backends: Optional[List[ai_hc.Backend]] = None,
-    channels_last: bool = False,
 ) -> dict:
     """Benchmark a specific problem across multiple backends.
 
@@ -279,9 +278,7 @@ def benchmark_problem(
                 )
                 logger.info(f"Variant: {variants[variant_idx]}")
 
-                model = runner.init_model(
-                    model_obj, variants[variant_idx], inits, channels_last=channels_last
-                )
+                model = runner.init_model(model_obj, variants[variant_idx], inits)
                 if backend == str(ai_hc.Backend.PYTORCH_COMPILE):
                     model.compile(dynamic=False)
                 # save pytorch model for correctness check
@@ -290,10 +287,7 @@ def benchmark_problem(
 
                 # prepare inputs
                 inputs = ai_hc.get_inputs(
-                    variants[variant_idx],
-                    spec_inputs,
-                    device=runner.device,
-                    channels_last=channels_last,
+                    variants[variant_idx], spec_inputs, device=runner.device
                 )
 
                 # correctness check, only if we have a reference PyTorch model and we're not currently benchmarking the PyTorch backend

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -193,24 +193,21 @@ class KernelRunner:
         model_obj: types.ModuleType,
         variant: dict,
         inits: list[dict],
-        channels_last: bool = False,
     ) -> torch.nn.Module:
         """Initialize model for given variant.
         Args:
             model_obj: Loaded base model
             variant: Specs' variant entry
-            spec_inits: Specs' inits entry
-            channels_last: If True, convert model to channels_last memory format
+            inits: Specs' inits entry
         Returns:
             PyTorch model
         """
         model_inits = ai_hc.get_inits(variant, inits)
         model_dtype = ai_hc.get_variant_torch_dtype(variant)
         model = model_obj(*model_inits).to(self.device, dtype=model_dtype)
-        if channels_last:
-            has_3d = any(p.ndim == 5 for p in model.parameters())
-            fmt = torch.channels_last_3d if has_3d else torch.channels_last
-            model = model.to(memory_format=fmt)
+        memory_format = ai_hc.get_variant_memory_format(variant)
+        if memory_format is not None:
+            model = model.to(memory_format=memory_format)
         return model
 
     def benchmark_model(self, variant, model, args) -> KernelStats:

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -189,19 +189,29 @@ class KernelRunner:
         return []
 
     def init_model(
-        self, model_obj: types.ModuleType, variant: dict, inits: list[dict]
+        self,
+        model_obj: types.ModuleType,
+        variant: dict,
+        inits: list[dict],
+        channels_last: bool = False,
     ) -> torch.nn.Module:
         """Initialize model for given variant.
         Args:
             model_obj: Loaded base model
             variant: Specs' variant entry
             spec_inits: Specs' inits entry
+            channels_last: If True, convert model to channels_last memory format
         Returns:
             PyTorch model
         """
         model_inits = ai_hc.get_inits(variant, inits)
         model_dtype = ai_hc.get_variant_torch_dtype(variant)
-        return model_obj(*model_inits).to(self.device, dtype=model_dtype)
+        model = model_obj(*model_inits).to(self.device, dtype=model_dtype)
+        if channels_last:
+            has_3d = any(p.ndim == 5 for p in model.parameters())
+            fmt = torch.channels_last_3d if has_3d else torch.channels_last
+            model = model.to(memory_format=fmt)
+        return model
 
     def benchmark_model(self, variant, model, args) -> KernelStats:
         """Gather model's performance.

--- a/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
+++ b/problems/specs/KernelBench/level1/86_conv_depthwise_separable_2D.yaml
@@ -14,6 +14,7 @@ inits:
 ci:
   - params: [x]
     dtype: float32
+    memory_format: channels_last
     dims:
       BATCH_SIZE: 2
       IN_CHANNELS: 4

--- a/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
+++ b/problems/specs/KernelBench/level2/1_Conv2D_ReLU_BiasAdd.yaml
@@ -25,6 +25,7 @@ ci:
 bench-gpu:
   - params: [X]
     dtype: float16
+    memory_format: channels_last
     dims:
       BATCH: 128
       IN_CHANNELS: 64

--- a/problems/specs/KernelBench/level3/11_VGG16.yaml
+++ b/problems/specs/KernelBench/level3/11_VGG16.yaml
@@ -9,6 +9,7 @@ inits:
 ci:
   - params: [X]
     dtype: float32
+    memory_format: channels_last
     dims:
       BATCH_SIZE: 1
       INPUT_CHANNELS: 3

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -309,5 +309,83 @@ class TestInputInitializations:
         assert inputs[10].dtype == torch.float16
 
 
+class TestMemoryFormat:
+    """Tests for variant memory_format field."""
+
+    def test_channels_last_applied_to_4d(self):
+        """Test channels_last memory format is applied to 4D tensors."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"N": 2, "C": 3, "H": 8, "W": 8},
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.MEMORY_FORMAT: "channels_last",
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["N", "C", "H", "W"],
+                ai_hc.InKey.TYPE: "float32",
+            },
+        }
+
+        tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert tensors[0].is_contiguous(memory_format=torch.channels_last)
+
+    def test_channels_last_not_applied_to_2d(self):
+        """Test channels_last memory format is not applied to non-4D tensors."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"M": 4, "N": 8},
+            ai_hc.VKey.TYPE: "float32",
+            ai_hc.VKey.MEMORY_FORMAT: "channels_last",
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["M", "N"],
+                ai_hc.InKey.TYPE: "float32",
+            },
+        }
+
+        tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert tensors[0].is_contiguous(memory_format=torch.contiguous_format)
+
+    def test_no_memory_format(self):
+        """Test that tensors are contiguous when no memory_format is specified."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"N": 2, "C": 3, "H": 8, "W": 8},
+            ai_hc.VKey.TYPE: "float32",
+        }
+        inputs = {
+            "X": {
+                ai_hc.InKey.SHAPE: ["N", "C", "H", "W"],
+                ai_hc.InKey.TYPE: "float32",
+            },
+        }
+
+        tensors = ai_hc.get_inputs(variant, inputs, device=torch.device("cpu"))
+        assert tensors[0].is_contiguous(memory_format=torch.contiguous_format)
+
+    def test_get_variant_memory_format(self):
+        """Test get_variant_memory_format returns correct format."""
+        assert ai_hc.get_variant_memory_format({}) is None
+        assert (
+            ai_hc.get_variant_memory_format({ai_hc.VKey.MEMORY_FORMAT: "channels_last"})
+            == torch.channels_last
+        )
+        assert (
+            ai_hc.get_variant_memory_format(
+                {ai_hc.VKey.MEMORY_FORMAT: "channels_last_3d"}
+            )
+            == torch.channels_last_3d
+        )
+
+    def test_invalid_memory_format(self):
+        """Test that invalid memory_format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid memory_format"):
+            ai_hc.get_variant_memory_format(
+                {ai_hc.VKey.MEMORY_FORMAT: "invalid_format"}
+            )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add memory_format as optional variant spec field (e.g. channels_last, channels_last_3d) similar to dtypev
- Add --variant flag to run named spec variants (e.g. bench-gpu-1)