### PR TITLE
Add Gluon and SYCL/CUTLASS backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![KernelBench Perf](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml/badge.svg)](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml)
 ![Status](https://img.shields.io/badge/status-beta-yellow)
 
-A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR, Gluon, SYCL/XeTLA) and devices (CPU, XPU, CUDA).
+A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR, Gluon, SYCL) and devices (CPU, XPU, CUDA).
 
-| | PyTorch | Triton | Helion | MLIR | Gluon | SYCL/XeTLA |
+| | PyTorch | Triton | Helion | MLIR | Gluon | SYCL |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **CPU** | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | **XPU** | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
@@ -75,7 +75,7 @@ ai-bench --xpu --helion
 # Gluon on XPU
 ai-bench --xpu --gluon
 
-# SYCL/XeTLA on XPU (requires env setup, see below)
+# SYCL on XPU (requires env setup, see below)
 ai-bench --xpu --sycl
 
 # Benchmark mode (with timing)
@@ -197,7 +197,7 @@ Notes legend:
 | `--helion` | Use Helion backend (default: PyTorch eager) |
 | `--mlir` | Use MLIR backend (default: PyTorch eager) |
 | `--gluon` | Use Gluon backend (default: PyTorch eager) |
-| `--sycl` | Use SYCL/XeTLA backend (default: PyTorch eager) |
+| `--sycl` | Use SYCL backend (default: PyTorch eager) |
 | `--bench` | Run benchmarks with timing (default: CI validation) |
 | `--gflops` | Report GFLOPS (default: TFLOPS) |
 | `--mbs` | Report MB/s (default: GB/s) |
@@ -231,7 +231,7 @@ All checks can be run using:
 pre-commit run -a
 ```
 
-## SYCL/XeTLA Backend Setup
+## SYCL Backend Setup
 
 The SYCL backend compiles and runs C++ CUTLASS kernels via `icpx`. It requires:
 
@@ -273,7 +273,7 @@ Environment variables used for project configuration:
 | `AIBENCH_GLUON_KERNELS_DIR` | Path to Gluon kernels directory |
 | `AIBENCH_SYCL_KERNELS_DIR` | Path to SYCL kernels directory |
 | `AIBENCH_SYCL_COMPILER` | Path to SYCL compiler (default: `icpx`) |
-| `AIBENCH_SYCL_INCLUDE` | Colon-separated include paths for CUTLASS headers |
+| `AIBENCH_SYCL_INCLUDE` | Colon-separated include paths for CUTLASS/SYCL headers |
 | `AIBENCH_SYCL_FLAGS` | Extra compiler flags (space-separated) |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![KernelBench Perf](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml/badge.svg)](https://github.com/libxsmm/AI-bench/actions/workflows/kernel_bench.yml)
 ![Status](https://img.shields.io/badge/status-beta-yellow)
 
-A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR) and devices (CPU, XPU, CUDA).
+A benchmarking framework for evaluating AI kernel implementations across multiple backends (PyTorch, Triton, Helion, MLIR, Gluon, SYCL/XeTLA) and devices (CPU, XPU, CUDA).
 
-| | PyTorch | Triton | Helion | MLIR |
-|:---:|:---:|:---:|:---:|:---:|
-| **CPU** | ✅ | ❌ | ❌ | ✅ |
-| **XPU** | ✅ | ✅ | ✅ | ❌ |
-| **CUDA** | ✅ | ✅ | ✅ | ❌ |
+| | PyTorch | Triton | Helion | MLIR | Gluon | SYCL/XeTLA |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **CPU** | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **XPU** | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| **CUDA** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 ✅ - Supported ⚠️ - Partially implemented ❌ - Unsupported
 
@@ -71,6 +71,12 @@ ai-bench --xpu --triton
 
 # Helion on XPU
 ai-bench --xpu --helion
+
+# Gluon on XPU
+ai-bench --xpu --gluon
+
+# SYCL/XeTLA on XPU (requires env setup, see below)
+ai-bench --xpu --sycl
 
 # Benchmark mode (with timing)
 ai-bench --xpu --bench
@@ -190,6 +196,8 @@ Notes legend:
 | `--torch-compile` | Use PyTorch compile mode (default: PyTorch eager) |
 | `--helion` | Use Helion backend (default: PyTorch eager) |
 | `--mlir` | Use MLIR backend (default: PyTorch eager) |
+| `--gluon` | Use Gluon backend (default: PyTorch eager) |
+| `--sycl` | Use SYCL/XeTLA backend (default: PyTorch eager) |
 | `--bench` | Run benchmarks with timing (default: CI validation) |
 | `--gflops` | Report GFLOPS (default: TFLOPS) |
 | `--mbs` | Report MB/s (default: GB/s) |
@@ -200,6 +208,8 @@ Notes legend:
 | `--triton-kernels-dir PATH` | Path to Triton kernels directory (CLI only) |
 | `--helion-kernels-dir PATH` | Path to Helion kernels directory (CLI only) |
 | `--mlir-kernels-dir PATH` | Path to MLIR kernels directory (CLI only) |
+| `--gluon-kernels-dir PATH` | Path to Gluon kernels directory (CLI only) |
+| `--sycl-kernels-dir PATH` | Path to SYCL kernels directory (CLI only) |
 | `--env-file PATH` | Path to .env file (default: auto-detect) |
 | `--no-env` | Disable loading .env config |
 
@@ -221,6 +231,30 @@ All checks can be run using:
 pre-commit run -a
 ```
 
+## SYCL/XeTLA Backend Setup
+
+The SYCL backend compiles and runs C++ CUTLASS kernels via `icpx`. It requires:
+
+1. **Intel oneAPI DPC++ compiler** (`icpx`) — install via [Intel oneAPI Base Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html)
+2. **Intel GPU drivers** (Level Zero runtime)
+3. **sycl-tla headers** — `git clone https://github.com/intel/sycl-tla`
+
+Set the following environment variables before running:
+
+```bash
+export AIBENCH_SYCL_COMPILER=icpx
+export AIBENCH_SYCL_INCLUDE=/path/to/sycl-tla/include:/path/to/sycl-tla/tools/util/include:/path/to/sycl-tla/examples/common
+ai-bench --xpu --sycl --bench
+```
+
+A helper script `env/sycl.sh` is provided for convenience:
+
+```bash
+export SYCL_TLA_DIR=/path/to/sycl-tla
+source env/sycl.sh
+ai-bench --xpu --sycl --bench
+```
+
 ## Config variables
 
 Environment variables used for project configuration:
@@ -236,6 +270,11 @@ Environment variables used for project configuration:
 | `AIBENCH_MLIR_LIB_PATH` | Paths to MLIR shared libraries (colon separated) |
 | `AIBENCH_MLIR_DUMP` | Dump imported MLIR IR |
 | `AIBENCH_MLIR_DUMP_OBJ` | Dump jitted MLIR to an object file |
+| `AIBENCH_GLUON_KERNELS_DIR` | Path to Gluon kernels directory |
+| `AIBENCH_SYCL_KERNELS_DIR` | Path to SYCL kernels directory |
+| `AIBENCH_SYCL_COMPILER` | Path to SYCL compiler (default: `icpx`) |
+| `AIBENCH_SYCL_INCLUDE` | Colon-separated include paths for CUTLASS headers |
+| `AIBENCH_SYCL_FLAGS` | Extra compiler flags (space-separated) |
 
 ## License
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -133,6 +133,18 @@ Environment file (.env) example:
         default=None,
         help="Path to MLIR kernels directory (default: auto-detect or AIBENCH_MLIR_KERNELS_DIR)",
     )
+    path_group.add_argument(
+        "--gluon-kernels-dir",
+        type=Path,
+        default=None,
+        help="Path to Gluon kernels directory (default: auto-detect or AIBENCH_GLUON_KERNELS_DIR)",
+    )
+    path_group.add_argument(
+        "--sycl-kernels-dir",
+        type=Path,
+        default=None,
+        help="Path to SYCL kernels directory (default: auto-detect or AIBENCH_SYCL_KERNELS_DIR)",
+    )
 
     # Device options
     device_group = parser.add_argument_group("device options")
@@ -176,6 +188,18 @@ Environment file (.env) example:
         action="store_true",
         default=False,
         help="Use MLIR backend",
+    )
+    backend_exclusive.add_argument(
+        "--gluon",
+        action="store_true",
+        default=False,
+        help="Use Gluon backend",
+    )
+    backend_exclusive.add_argument(
+        "--sycl",
+        action="store_true",
+        default=False,
+        help="Use SYCL/XeTLA backend",
     )
 
     # Run mode
@@ -248,6 +272,8 @@ def main(argv: list[str] | None = None) -> int:
         or args.triton_kernels_dir
         or args.helion_kernels_dir
         or args.mlir_kernels_dir
+        or args.gluon_kernels_dir
+        or args.sycl_kernels_dir
     ):
         finder.configure(
             specs_dir=args.specs_dir,
@@ -255,6 +281,8 @@ def main(argv: list[str] | None = None) -> int:
             triton_kernels_dir=args.triton_kernels_dir,
             helion_kernels_dir=args.helion_kernels_dir,
             mlir_kernels_dir=args.mlir_kernels_dir,
+            gluon_kernels_dir=args.gluon_kernels_dir,
+            sycl_kernels_dir=args.sycl_kernels_dir,
         )
 
     # Determine device
@@ -274,6 +302,10 @@ def main(argv: list[str] | None = None) -> int:
         backend = core.Backend.PYTORCH_COMPILE
     elif args.mlir:
         backend = core.Backend.MLIR
+    elif args.gluon:
+        backend = core.Backend.GLUON
+    elif args.sycl:
+        backend = core.Backend.SYCL
     else:
         backend = core.Backend.PYTORCH
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -199,7 +199,7 @@ Environment file (.env) example:
         "--sycl",
         action="store_true",
         default=False,
-        help="Use SYCL/XeTLA backend",
+        help="Use SYCL backend",
     )
 
     # Run mode

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -77,6 +77,8 @@ class Backend(StrEnum):
     TRITON = "triton"
     HELION = "helion"
     MLIR = "mlir"
+    GLUON = "gluon"
+    SYCL = "sycl"
 
 
 # Default tolerance values (match current hardcoded behavior).

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -223,6 +223,7 @@ class KernelBenchRunner(KernelRunner):
             m = dims.get("M", dims.get("N", 128))
             n = dims.get("N", m)
             k = dims.get("K", m)
+            dtype = variant.get(ai_hc.VKey.TYPE)
 
             is_ci = self.spec_type == ai_hc.SpecKey.V_CI
             iterations = 0 if is_ci else 20
@@ -236,6 +237,7 @@ class KernelBenchRunner(KernelRunner):
                 k=k,
                 iterations=iterations,
                 verify=1,
+                dtype=dtype,
             )
 
             if not result.success:

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -192,9 +192,9 @@ class KernelBenchRunner(KernelRunner):
         self, kernel_path: Path, spec_path: Path
     ) -> list[KernelStats] | None:
         """Compile and run a native (C++) kernel via subprocess."""
-        from ai_bench.sycl.compiler import SYCLCompiler
-
         import yaml
+
+        from ai_bench.sycl.compiler import SYCLCompiler
 
         if not kernel_path.is_file():
             self.logger.debug(f"Missing native kernel: {kernel_path}")

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -11,6 +11,9 @@ from ai_bench import utils as ai_utils
 from ai_bench.harness import core as ai_hc
 from ai_bench.utils.csv_logger import CSVLogger
 
+_NATIVE_BACKENDS = frozenset({ai_hc.Backend.SYCL})
+_NATIVE_EXTENSIONS = {ai_hc.Backend.SYCL: ".cpp"}
+
 
 class KernelBenchRunner(KernelRunner):
     """
@@ -86,6 +89,14 @@ class KernelBenchRunner(KernelRunner):
             self.kernels = (
                 ai_utils.mlir_kernels_dir() / self.device.type / "KernelBench"
             )
+        elif self.backend == ai_hc.Backend.GLUON:
+            self.kernels = (
+                ai_utils.gluon_kernels_dir() / self.device.type / "KernelBench"
+            )
+        elif self.backend == ai_hc.Backend.SYCL:
+            self.kernels = (
+                ai_utils.sycl_kernels_dir() / self.device.type / "KernelBench"
+            )
         else:
             raise ValueError(f"Unsupported backend: {self.backend}")
 
@@ -103,10 +114,16 @@ class KernelBenchRunner(KernelRunner):
             [Path(entry) for entry in os.scandir(self.specs) if entry.is_dir()]
         )
 
+    def _kernel_extension(self) -> str:
+        """Return the kernel file extension for the current backend."""
+        return _NATIVE_EXTENSIONS.get(self.backend, ".py")
+
     def run_kernels(self):
         """Run all KernelBench kernels."""
         self.logger.info(f"Kernels: {self.kernels}")
         self.print_info(self.logger.info)
+
+        ext = self._kernel_extension()
 
         # Iterate over specs of kernel levels.
         for spec_dir in self.get_spec_dirs():
@@ -114,7 +131,7 @@ class KernelBenchRunner(KernelRunner):
             for file in sorted(os.listdir(spec_dir)):
                 # Spec and kernel file names are expected to be identical.
                 kernel_dir = self.kernels / spec_dir.name
-                kernel_file = Path(kernel_dir / file.replace(".yaml", ".py"))
+                kernel_file = Path(kernel_dir / file.replace(".yaml", ext))
 
                 # Run the kernel in all compatible variants.
                 run_stats: list[KernelStats] | None = self.run_kernel_spec(
@@ -152,3 +169,111 @@ class KernelBenchRunner(KernelRunner):
                         }
                         row.update(aibench_env)
                         self.csv_logger.log(row)
+
+    def run_kernel_spec(
+        self, kernel_path: Path | str, spec_path: Path | str
+    ) -> list[KernelStats] | None:
+        """Run a kernel with a spec.
+
+        Dispatches to native (subprocess) execution for SYCL backends,
+        otherwise falls through to the base Python-based runner.
+        """
+        if isinstance(kernel_path, str):
+            kernel_path = Path(kernel_path)
+        if isinstance(spec_path, str):
+            spec_path = Path(spec_path)
+
+        if self.backend in _NATIVE_BACKENDS:
+            return self._run_native_kernel_spec(kernel_path, spec_path)
+
+        return super().run_kernel_spec(kernel_path, spec_path)
+
+    def _run_native_kernel_spec(
+        self, kernel_path: Path, spec_path: Path
+    ) -> list[KernelStats] | None:
+        """Compile and run a native (C++) kernel via subprocess."""
+        from ai_bench.sycl.compiler import SYCLCompiler
+
+        import yaml
+
+        if not kernel_path.is_file():
+            self.logger.debug(f"Missing native kernel: {kernel_path}")
+            return None
+
+        with open(spec_path) as f:
+            spec = yaml.safe_load(f)
+
+        if self.spec_type not in spec:
+            return None
+
+        compiler = SYCLCompiler()
+        binary = compiler.compile(kernel_path)
+        if binary is None:
+            self.logger.error(f"Failed to compile: {kernel_path}")
+            return None
+
+        self.logger.info(
+            f"Kernel: {spec_path.parent.name} / {spec_path.name} [{self.backend}]"
+        )
+
+        variants = spec[self.spec_type]
+        stats = []
+        for variant in variants:
+            dims = variant.get("dims", {})
+            m = dims.get("M", dims.get("N", 128))
+            n = dims.get("N", m)
+            k = dims.get("K", m)
+
+            is_ci = self.spec_type == ai_hc.SpecKey.V_CI
+            iterations = 0 if is_ci else 20
+
+            self.logger.info(f"{'Validating' if is_ci else 'Benchmarking'}: {variant}")
+
+            result = compiler.run(
+                binary,
+                m=m,
+                n=n,
+                k=k,
+                iterations=iterations,
+                verify=1,
+            )
+
+            if not result.success:
+                self.logger.error(f"Execution failed: {result.error}")
+                if result.raw_output:
+                    self.logger.error(f"Output:\n{result.raw_output}")
+                continue
+
+            if result.passed is False:
+                self.logger.error("Correctness check FAILED")
+                continue
+
+            if is_ci:
+                self.logger.info("  Disposition: Passed")
+                continue
+
+            time_us = (result.time_ms * 1000) if result.time_ms else 0.0
+            flop = ai_hc.get_flop(variant)
+            flops_val = result.tflops
+            flops_unit = str(config.FlopsUnit.TFLOPS) if flops_val else None
+
+            self.logger.info(
+                f"  time [us]: {time_us:.6f} {flops_unit or ''}: {flops_val or ''}"
+            )
+
+            stats.append(
+                KernelStats(
+                    variant=variant,
+                    meas_us=time_us,
+                    flop=flop,
+                    flops=flops_val,
+                    flops_unit=flops_unit,
+                    flops_note=None,
+                    mem_bytes=ai_hc.get_mem_bytes(variant),
+                    mem_bw=None,
+                    mem_bw_unit=None,
+                    mem_note=None,
+                )
+            )
+
+        return stats if stats else None

--- a/ai_bench/sycl/__init__.py
+++ b/ai_bench/sycl/__init__.py
@@ -1,0 +1,3 @@
+from ai_bench.sycl.compiler import SYCLCompiler
+
+__all__ = ["SYCLCompiler"]

--- a/ai_bench/sycl/compiler.py
+++ b/ai_bench/sycl/compiler.py
@@ -11,13 +11,13 @@ Environment variables:
     AIBENCH_SYCL_TARGET     Target device for AOT compilation (default: bmg-g31)
 """
 
+from dataclasses import dataclass
 import logging
 import os
+from pathlib import Path
 import re
 import subprocess
 import tempfile
-from dataclasses import dataclass
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/ai_bench/sycl/compiler.py
+++ b/ai_bench/sycl/compiler.py
@@ -1,0 +1,218 @@
+"""SYCL/XeTLA kernel compiler and runner.
+
+Compiles standalone SYCL C++ kernels (e.g. CUTLASS SYCL GEMM examples) into
+executables and runs them as subprocesses. The compiled binary is expected to
+print timing and correctness results to stdout.
+
+Environment variables:
+    AIBENCH_SYCL_COMPILER   Path to the SYCL compiler (default: icpx)
+    AIBENCH_SYCL_FLAGS      Extra compiler flags (space-separated)
+    AIBENCH_SYCL_INCLUDE    Colon-separated include paths for CUTLASS/SYCL headers
+    AIBENCH_SYCL_TARGET     Target device for AOT compilation (default: bmg-g31)
+"""
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SYCLRunResult:
+    success: bool
+    passed: bool | None = None
+    time_ms: float | None = None
+    tflops: float | None = None
+    raw_output: str = ""
+    error: str = ""
+
+
+class SYCLCompiler:
+    """Compile and execute SYCL C++ kernel sources."""
+
+    _DEFAULT_DEFINES = ["-DCUTLASS_ENABLE_SYCL", "-DSYCL_INTEL_TARGET"]
+    _DEFAULT_FLAGS = ["-O2", "-std=c++17", "-fno-sycl-instrument-device-code"]
+
+    def __init__(
+        self,
+        compiler: str | None = None,
+        flags: list[str] | None = None,
+        include_dirs: list[str] | None = None,
+        target_device: str | None = None,
+    ):
+        self.compiler = compiler or os.environ.get("AIBENCH_SYCL_COMPILER", "icpx")
+        self.target_device = target_device or os.environ.get("AIBENCH_SYCL_TARGET", "")
+
+        if include_dirs is not None:
+            self.include_dirs = include_dirs
+        else:
+            env_include = os.environ.get("AIBENCH_SYCL_INCLUDE", "")
+            self.include_dirs = [d for d in env_include.split(":") if d]
+
+        if flags is not None:
+            self.flags = flags
+        else:
+            env_flags = os.environ.get("AIBENCH_SYCL_FLAGS", "")
+            self.flags = env_flags.split() if env_flags else list(self._DEFAULT_FLAGS)
+
+        self._build_dir = Path(tempfile.mkdtemp(prefix="aibench_sycl_"))
+
+    def compile(self, source_path: Path) -> Path | None:
+        """Compile a SYCL C++ source file into an executable.
+
+        Args:
+            source_path: Path to .cpp file
+        Returns:
+            Path to compiled binary, or None on failure
+        """
+        binary_name = source_path.stem
+        binary_path = self._build_dir / binary_name
+
+        cmd = [self.compiler, "-fsycl"]
+        cmd.extend(self._DEFAULT_DEFINES)
+        cmd.extend(self.flags)
+
+        if self.target_device:
+            cmd.extend(
+                [
+                    "-fsycl-targets=spir64_gen",
+                    "-Xsycl-target-backend=spir64_gen",
+                    f"-device {self.target_device}",
+                    "-Xspirv-translator",
+                    "-spirv-ext=+SPV_INTEL_split_barrier"
+                    ",+SPV_INTEL_2d_block_io"
+                    ",+SPV_INTEL_subgroup_matrix_multiply_accumulate",
+                ]
+            )
+
+        for inc_dir in self.include_dirs:
+            cmd.extend(["-I", inc_dir])
+
+        cmd.extend(["-o", str(binary_path), str(source_path)])
+
+        logger.info("Compiling SYCL kernel: %s", " ".join(cmd))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except FileNotFoundError:
+            logger.error(
+                "SYCL compiler not found: %s. Set AIBENCH_SYCL_COMPILER.",
+                self.compiler,
+            )
+            return None
+        except subprocess.TimeoutExpired:
+            logger.error("SYCL compilation timed out for %s", source_path)
+            return None
+
+        if result.returncode != 0:
+            logger.error("SYCL compilation failed:\n%s", result.stderr)
+            return None
+
+        logger.info("Compiled: %s", binary_path)
+        return binary_path
+
+    def run(
+        self,
+        binary_path: Path,
+        m: int,
+        n: int,
+        k: int,
+        iterations: int = 20,
+        verify: int = 1,
+    ) -> SYCLRunResult:
+        """Execute a compiled SYCL kernel binary.
+
+        Args:
+            binary_path: Path to compiled executable
+            m, n, k: Matrix dimensions
+            iterations: Benchmark iterations
+            verify: Whether to verify correctness (1=yes, 0=no)
+        Returns:
+            Parsed execution results
+        """
+        cmd = [
+            str(binary_path),
+            f"--m={m}",
+            f"--n={n}",
+            f"--k={k}",
+            f"--iterations={iterations}",
+            f"--verify={verify}",
+        ]
+
+        logger.info("Running SYCL kernel: %s", " ".join(cmd))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            return SYCLRunResult(success=False, error="Execution timed out")
+        except Exception as e:
+            return SYCLRunResult(success=False, error=str(e))
+
+        output = result.stdout + result.stderr
+
+        if result.returncode != 0:
+            return SYCLRunResult(
+                success=False, raw_output=output, error=f"Exit code {result.returncode}"
+            )
+
+        return self._parse_output(output)
+
+    def compile_and_run(
+        self,
+        source_path: Path,
+        m: int,
+        n: int,
+        k: int,
+        iterations: int = 20,
+        verify: int = 1,
+    ) -> SYCLRunResult:
+        """Compile a source file and run it in one step."""
+        binary = self.compile(source_path)
+        if binary is None:
+            return SYCLRunResult(success=False, error="Compilation failed")
+        return self.run(binary, m=m, n=n, k=k, iterations=iterations, verify=verify)
+
+    @staticmethod
+    def _parse_output(output: str) -> SYCLRunResult:
+        """Parse stdout from a CUTLASS SYCL kernel binary.
+
+        Expected output format:
+            Disposition: Passed
+            Problem Size: 5120x4096x4096x1
+            Cutlass GEMM Performance:     [123.456]TFlop/s  (1.2345)ms
+        """
+        passed = None
+        tflops = None
+        time_ms = None
+
+        disp_match = re.search(r"Disposition:\s*(Passed|Failed)", output)
+        if disp_match:
+            passed = disp_match.group(1) == "Passed"
+
+        perf_match = re.search(r"\[([0-9.]+)\]\s*TFlop/s\s+\(([0-9.]+)\)\s*ms", output)
+        if perf_match:
+            tflops = float(perf_match.group(1))
+            time_ms = float(perf_match.group(2))
+
+        return SYCLRunResult(
+            success=True,
+            passed=passed,
+            tflops=tflops,
+            time_ms=time_ms,
+            raw_output=output,
+        )

--- a/ai_bench/sycl/compiler.py
+++ b/ai_bench/sycl/compiler.py
@@ -1,4 +1,4 @@
-"""SYCL/XeTLA kernel compiler and runner.
+"""SYCL kernel compiler and runner.
 
 Compiles standalone SYCL C++ kernels (e.g. CUTLASS SYCL GEMM examples) into
 executables and runs them as subprocesses. The compiled binary is expected to
@@ -129,6 +129,7 @@ class SYCLCompiler:
         k: int,
         iterations: int = 20,
         verify: int = 1,
+        dtype: str | None = None,
     ) -> SYCLRunResult:
         """Execute a compiled SYCL kernel binary.
 
@@ -137,6 +138,7 @@ class SYCLCompiler:
             m, n, k: Matrix dimensions
             iterations: Benchmark iterations
             verify: Whether to verify correctness (1=yes, 0=no)
+            dtype: Data type hint (e.g. "bfloat16", "float16"). Forwarded to binary if set.
         Returns:
             Parsed execution results
         """
@@ -148,6 +150,8 @@ class SYCLCompiler:
             f"--iterations={iterations}",
             f"--verify={verify}",
         ]
+        if dtype:
+            cmd.append(f"--dtype={dtype}")
 
         logger.info("Running SYCL kernel: %s", " ".join(cmd))
 
@@ -180,12 +184,15 @@ class SYCLCompiler:
         k: int,
         iterations: int = 20,
         verify: int = 1,
+        dtype: str | None = None,
     ) -> SYCLRunResult:
         """Compile a source file and run it in one step."""
         binary = self.compile(source_path)
         if binary is None:
             return SYCLRunResult(success=False, error="Compilation failed")
-        return self.run(binary, m=m, n=n, k=k, iterations=iterations, verify=verify)
+        return self.run(
+            binary, m=m, n=n, k=k, iterations=iterations, verify=verify, dtype=dtype
+        )
 
     @staticmethod
     def _parse_output(output: str) -> SYCLRunResult:

--- a/ai_bench/utils/__init__.py
+++ b/ai_bench/utils/__init__.py
@@ -2,12 +2,14 @@ from .equations import eval_ast
 from .equations import eval_eq
 from .finder import ConfigurationError
 from .finder import configure
+from .finder import gluon_kernels_dir
 from .finder import helion_kernels_dir
 from .finder import kernel_bench_dir
 from .finder import mlir_kernels_dir
 from .finder import project_root
 from .finder import reset_configuration
 from .finder import specs
+from .finder import sycl_kernels_dir
 from .finder import triton_kernels_dir
 from .flop_counter import count_torch_flop
 from .importer import import_from_path
@@ -22,6 +24,7 @@ __all__ = [
     "count_torch_memory_bytes",
     "eval_ast",
     "eval_eq",
+    "gluon_kernels_dir",
     "helion_kernels_dir",
     "import_from_path",
     "kernel_bench_dir",
@@ -29,5 +32,6 @@ __all__ = [
     "project_root",
     "reset_configuration",
     "specs",
+    "sycl_kernels_dir",
     "triton_kernels_dir",
 ]

--- a/ai_bench/utils/finder.py
+++ b/ai_bench/utils/finder.py
@@ -16,6 +16,8 @@ _kernels_dir: Path | None = None
 _triton_kernels_dir: Path | None = None
 _helion_kernels_dir: Path | None = None
 _mlir_kernels_dir: Path | None = None
+_gluon_kernels_dir: Path | None = None
+_sycl_kernels_dir: Path | None = None
 _env_loaded: bool = False
 
 
@@ -86,6 +88,8 @@ def configure(
     triton_kernels_dir: Path | str | None = None,
     helion_kernels_dir: Path | str | None = None,
     mlir_kernels_dir: Path | str | None = None,
+    gluon_kernels_dir: Path | str | None = None,
+    sycl_kernels_dir: Path | str | None = None,
 ) -> None:
     """Configure library paths.
 
@@ -97,6 +101,8 @@ def configure(
         triton_kernels_dir: Path to Triton kernel implementations
         helion_kernels_dir: Path to Helion kernel implementations
         mlir_kernels_dir: Path to MLIR kernel implementations
+        gluon_kernels_dir: Path to Gluon kernel implementations
+        sycl_kernels_dir: Path to SYCL kernel implementations
 
     Example:
         >>> import ai_bench
@@ -110,7 +116,9 @@ def configure(
         _kernels_dir, \
         _triton_kernels_dir, \
         _helion_kernels_dir, \
-        _mlir_kernels_dir
+        _mlir_kernels_dir, \
+        _gluon_kernels_dir, \
+        _sycl_kernels_dir
 
     if specs_dir is not None:
         _specs_dir = Path(specs_dir)
@@ -122,6 +130,10 @@ def configure(
         _helion_kernels_dir = Path(helion_kernels_dir)
     if mlir_kernels_dir is not None:
         _mlir_kernels_dir = Path(mlir_kernels_dir)
+    if gluon_kernels_dir is not None:
+        _gluon_kernels_dir = Path(gluon_kernels_dir)
+    if sycl_kernels_dir is not None:
+        _sycl_kernels_dir = Path(sycl_kernels_dir)
 
 
 def reset_configuration() -> None:
@@ -135,12 +147,16 @@ def reset_configuration() -> None:
         _triton_kernels_dir, \
         _helion_kernels_dir, \
         _mlir_kernels_dir, \
+        _gluon_kernels_dir, \
+        _sycl_kernels_dir, \
         _env_loaded
     _specs_dir = None
     _kernels_dir = None
     _triton_kernels_dir = None
     _helion_kernels_dir = None
     _mlir_kernels_dir = None
+    _gluon_kernels_dir = None
+    _sycl_kernels_dir = None
     _env_loaded = False
 
 
@@ -336,4 +352,62 @@ def mlir_kernels_dir() -> Path:
         "AIBENCH_MLIR_KERNELS_DIR",
         default,
         "MLIR kernels directory",
+    )
+
+
+def gluon_kernels_dir() -> Path:
+    """Path to the Gluon kernels directory.
+
+    Can be configured via:
+    - ai_bench.configure(gluon_kernels_dir=...)
+    - AIBENCH_GLUON_KERNELS_DIR environment variable
+    - Auto-detected from project structure
+
+    Returns:
+        Path to Gluon kernels directory
+
+    Raises:
+        ConfigurationError: If path cannot be determined
+    """
+
+    def default() -> Path:
+        path = project_root() / "backends" / "gluon"
+        if not path.exists():
+            raise FileNotFoundError(f"Default Gluon kernels path not found: {path}")
+        return path
+
+    return _get_path(
+        _gluon_kernels_dir,
+        "AIBENCH_GLUON_KERNELS_DIR",
+        default,
+        "Gluon kernels directory",
+    )
+
+
+def sycl_kernels_dir() -> Path:
+    """Path to the SYCL kernels directory.
+
+    Can be configured via:
+    - ai_bench.configure(sycl_kernels_dir=...)
+    - AIBENCH_SYCL_KERNELS_DIR environment variable
+    - Auto-detected from project structure
+
+    Returns:
+        Path to SYCL kernels directory
+
+    Raises:
+        ConfigurationError: If path cannot be determined
+    """
+
+    def default() -> Path:
+        path = project_root() / "backends" / "sycl"
+        if not path.exists():
+            raise FileNotFoundError(f"Default SYCL kernels path not found: {path}")
+        return path
+
+    return _get_path(
+        _sycl_kernels_dir,
+        "AIBENCH_SYCL_KERNELS_DIR",
+        default,
+        "SYCL kernels directory",
     )

--- a/backends/sycl/xpu/KernelBench/level1/1_Square_matrix_multiplication_.cpp
+++ b/backends/sycl/xpu/KernelBench/level1/1_Square_matrix_multiplication_.cpp
@@ -1,0 +1,350 @@
+/***************************************************************************************************
+ * Copyright (C) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * Copyright (C) 2025 -2026 Intel Corporation, All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/collective/xe_epilogue.hpp"
+#include "cutlass/epilogue/fusion/xe_callbacks.hpp"
+#include "cutlass/gemm/device/gemm_universal.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/collective/collective_mma.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+#include <cute/tensor.hpp>
+#include <random>
+
+#include "cutlass/util/command_line.h"
+#include "cutlass/util/device_memory.h"
+#include "cutlass/util/packed_stride.hpp"
+#include "cutlass/util/reference/device/gemm_complex.h"
+#include "cutlass/util/reference/device/tensor_compare.h"
+#include "sycl_common.hpp"
+#include "helper.h"
+
+using namespace cute;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct Options {
+
+  bool help;
+  bool error;
+
+  int m, n, k, l, iterations, verify;
+  float alpha, beta;
+
+  Options():
+    help(false),
+    error(false),
+    m(5120), n(4096), k(4096), l(1), iterations(20), verify(1),
+    alpha(1.f), beta(0.f)
+  { }
+
+  void parse(int argc, char const **args) {
+    cutlass::CommandLine cmd(argc, args);
+
+    if (cmd.check_cmd_line_flag("help")) {
+      help = true;
+      return;
+    }
+
+    cmd.get_cmd_line_argument("m", m, 5120);
+    cmd.get_cmd_line_argument("n", n, 4096);
+    cmd.get_cmd_line_argument("k", k, 4096);
+    cmd.get_cmd_line_argument("l", l, 1);
+    cmd.get_cmd_line_argument("alpha", alpha, 1.f);
+    cmd.get_cmd_line_argument("beta", beta, 0.f);
+    cmd.get_cmd_line_argument("iterations", iterations, 100);
+    cmd.get_cmd_line_argument("verify", verify, 1);
+  }
+
+  std::ostream & print_usage(std::ostream &out) const {
+
+    out << "BMG GEMM Example\n\n"
+      << "Options:\n\n"
+      << "  --help                      If specified, displays this usage statement\n\n"
+      << "  --m=<int>                   Sets the M extent of the GEMM\n"
+      << "  --n=<int>                   Sets the N extent of the GEMM\n"
+      << "  --k=<int>                   Sets the K extent of the GEMM\n"
+      << "  --l=<int>                   Sets the L extent (batch count) of the GEMM\n"
+      << "  --alpha=<s32>               Epilogue scalar alpha\n"
+      << "  --beta=<s32>                Epilogue scalar beta\n\n"
+      << "  --iterations=<int>          Iterations\n\n"
+      << "  --verify=<int>              Specify whether to verify.\n\n";
+
+    return out;
+  }
+};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <
+  class Gemm
+>
+struct ExampleRunner {
+
+  using StrideA = typename Gemm::GemmKernel::StrideA;
+  using StrideB = typename Gemm::GemmKernel::StrideB;
+  using StrideC = typename Gemm::GemmKernel::StrideC;
+  using StrideD = typename Gemm::GemmKernel::StrideD;
+
+  using LayoutA = typename Gemm::LayoutA;
+  using LayoutB = typename Gemm::LayoutB;
+  using LayoutC = typename Gemm::LayoutC;
+  using LayoutD = typename Gemm::LayoutD;
+
+  using ElementA = typename Gemm::ElementA;
+  using ElementB = typename Gemm::ElementB;
+  using ElementAccumulator = typename Gemm::ElementAccumulator;
+
+  using CollectiveEpilogue = typename Gemm::CollectiveEpilogue;
+  using ElementC = typename Gemm::ElementC;
+  using ElementOutput = typename CollectiveEpilogue::ElementOutput;
+  using ElementCompute = typename CollectiveEpilogue::ElementCompute;
+
+  using ProblemShapeType = typename Gemm::GemmKernel::ProblemShape;
+
+  //
+  // Data members
+  //
+
+  StrideA stride_A;
+  StrideB stride_B;
+  StrideC stride_C;
+  StrideD stride_D;
+  uint64_t seed = 0;
+
+  cutlass::DeviceAllocation<ElementA> block_A;
+  cutlass::DeviceAllocation<ElementB> block_B;
+  cutlass::DeviceAllocation<ElementC> block_C;
+  cutlass::DeviceAllocation<ElementOutput> block_D;
+  cutlass::DeviceAllocation<ElementOutput> block_ref_D;
+
+  //
+  // Methods
+  //
+
+  bool verify(const ProblemShapeType& problem_size, ElementCompute alpha, ElementCompute beta) {
+    auto [M, N, K, L] = problem_size;
+
+    cutlass::TensorRef ref_A(block_A.get(), LayoutA::packed({M, K}));
+    cutlass::TensorRef ref_B(block_B.get(), LayoutB::packed({K, N}));
+    cutlass::TensorRef ref_C(block_C.get(), LayoutC::packed({M, N}));
+    cutlass::TensorRef ref_D(block_ref_D.get(), LayoutD::packed({M, N}));
+
+    cutlass::reference::device::GemmComplex(
+          {M, N, K},
+          alpha,
+          ref_A,
+          cutlass::ComplexTransform::kNone,
+          ref_B,
+          cutlass::ComplexTransform::kNone,
+          beta,
+          ref_C,
+          ref_D,
+          ElementAccumulator(0),
+          L,     // batch_count
+          M * K, // batch_stride_A
+          K * N, // batch_stride_B
+          M * N, // batch_stride_C
+          M * N  // batch_stride_D
+        );
+
+    compat::wait();
+
+    bool passed = cutlass::reference::device::BlockCompareEqual(
+      block_ref_D.get(), block_D.get(), block_D.size());
+
+    return passed;
+  }
+
+  void initialize(const ProblemShapeType& problem_size) {
+    auto problem_shape_MNKL = cute::append<4>(problem_size, 1);
+    auto [M, N, K, L] = problem_shape_MNKL;
+
+    stride_A = cutlass::make_cute_packed_stride(StrideA{}, cute::make_shape(M, K, L));
+    stride_B = cutlass::make_cute_packed_stride(StrideB{}, cute::make_shape(N, K, L));
+    stride_C = cutlass::make_cute_packed_stride(StrideC{}, cute::make_shape(M, N, L));
+    stride_D = cutlass::make_cute_packed_stride(StrideD{}, cute::make_shape(M, N, L));
+
+    block_A.reset(static_cast<std::size_t>(M) * K * L);
+    block_B.reset(static_cast<std::size_t>(K) * N * L);
+    block_C.reset(static_cast<std::size_t>(M) * N * L);
+    block_D.reset(static_cast<std::size_t>(M) * N * L);
+    block_ref_D.reset(static_cast<std::size_t>(M) * N * L);
+
+    initialize_block(block_A, seed + 2023);
+    initialize_block(block_B, seed + 2022);
+    initialize_block(block_C, seed + 2021);
+  }
+
+  cutlass::Status run(const Options& options, const cutlass::KernelHardwareInfo& hw_info) {
+    ProblemShapeType problem_size = ProblemShapeType{options.m, options.n, options.k, options.l};
+
+    initialize(problem_size);
+
+    typename Gemm::GemmKernel::Arguments arguments{
+      cutlass::gemm::GemmUniversalMode::kGemm,
+      problem_size,
+      {block_A.get(), stride_A, block_B.get(), stride_B},
+      {{options.alpha, options.beta}, block_C.get(), stride_C, block_D.get(), stride_D},
+      hw_info
+    };
+
+    Gemm gemm_op;
+
+    size_t workspace_size = Gemm::get_workspace_size(arguments);
+    cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+    if (gemm_op.can_implement(arguments) != cutlass::Status::kSuccess){
+      std::cout << "Invalid Problem Size: " << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      std::exit(1);
+    }
+
+    CUTLASS_CHECK(gemm_op.initialize(arguments, workspace.get()));
+
+    CUTLASS_CHECK(gemm_op.run());
+
+    compat::wait();
+
+    if (options.verify != 0) {
+      bool passed = verify(problem_size, options.alpha, options.beta);
+      std::cout << "Disposition: " << (passed ? "Passed" : "Failed") << std::endl;
+
+      if (!passed) return cutlass::Status::kErrorInternal;
+    } else {
+      std::cout << "Disposition is skipped." << std::endl;
+    }
+
+    if (options.iterations > 0) {
+      GPU_Clock timer;
+      timer.start();
+      for (int i = 0; i < options.iterations; ++i) {
+        gemm_op.run();
+      }
+      compat::wait();
+
+      float cute_time = timer.seconds() / options.iterations;
+      double tflops = (2.0 * options.m * options.n * options.k * options.l) * 1e-12;
+      std::cout << "Problem Size: " << options.m << 'x' << options.n << 'x' << options.k << 'x' << options.l << std::endl;
+      printf("Cutlass GEMM Performance:     [%4.3f]TFlop/s  (%6.4f)ms\n", tflops / cute_time, cute_time*1000);
+    }
+
+    return cutlass::Status::kSuccess;
+  }
+
+};
+
+int main(int argc, const char** argv)
+{
+  Options options;
+
+  options.parse(argc, argv);
+
+  if (options.help) {
+    options.print_usage(std::cout) << std::endl;
+    return 0;
+  }
+
+  if (options.error) {
+    std::cerr << "Aborting execution." << std::endl;
+    return -1;
+  }
+
+  cutlass::KernelHardwareInfo hw_info;
+  hw_info.sm_count = cutlass::KernelHardwareInfo::query_device_multiprocessor_count(hw_info.device_id);
+
+  using ElementAccumulator = float;
+  using ElementComputeEpilogue = float;
+  using ElementInputA = bfloat16_t;
+  using ElementInputB = bfloat16_t;
+  using ElementOutput = float;
+
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  using GmemTiledCopyA = void;
+  using GmemTiledCopyB = void;
+
+  using TileShape = Shape<_256, _256, _32>;
+
+  using TiledMma = typename TiledMMAHelper<MMA_Atom<XE_DPAS_TT<8, float, cute::bfloat16_t>>, Layout<TileShape>, Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>>::TiledMMA;
+
+  constexpr int PipelineStages = 2;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopXeL1Staged<PipelineStages>;
+  using EpilogueDispatchPolicy = cutlass::epilogue::IntelXeGeneric;
+
+  using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<ElementOutput, ElementComputeEpilogue,
+          ElementAccumulator, ElementAccumulator, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using FusionCallbacks = cutlass::epilogue::fusion::FusionCallbacks<EpilogueDispatchPolicy, EpilogueOp, TileShape,
+          decltype(tile_shape(TiledMma()))>;
+
+  using CollectiveEpilogue = cutlass::epilogue::collective::CollectiveEpilogue<
+          EpilogueDispatchPolicy,
+          TileShape,
+          void,
+          ElementAccumulator,
+          cutlass::gemm::TagToStrideC_t<LayoutC>,
+          ElementOutput,
+          cutlass::gemm::TagToStrideC_t<LayoutD>,
+          FusionCallbacks,
+          void,
+          void>;
+
+  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+          GEMMDispatchPolicy,
+          TileShape,
+          ElementInputA,
+          cutlass::gemm::TagToStrideA_t<LayoutA>,
+          ElementInputB,
+          cutlass::gemm::TagToStrideB_t<LayoutB>,
+          TiledMma,
+          GmemTiledCopyA, void, void, cute::identity,  // A
+          GmemTiledCopyB, void, void, cute::identity   // B
+  >;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+          Shape<int, int, int, int>,
+          CollectiveMainloop,
+          CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  ExampleRunner<Gemm> runner;
+
+  CUTLASS_CHECK(runner.run(options, hw_info));
+
+  return 0;
+}

--- a/env/sycl.sh
+++ b/env/sycl.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Source this file to set up the SYCL/CUTLASS build environment.
+#
+# Usage:
+#   export SYCL_TLA_DIR=/path/to/sycl-tla
+#   source env_sycl.sh
+#
+# Requires:
+#   - Intel oneAPI DPC++ compiler (icpx)
+#   - Intel GPU drivers (Level Zero)
+#   - sycl-tla headers (git clone https://github.com/intel/sycl-tla)
+
+set +u
+
+# oneAPI compiler (source setvars.sh if available)
+if [ -n "$ONEAPI_ROOT" ] && [ -f "$ONEAPI_ROOT/setvars.sh" ]; then
+    source "$ONEAPI_ROOT/setvars.sh" --force 2>/dev/null
+fi
+
+# Verify icpx is available
+if ! command -v icpx &>/dev/null; then
+    echo "ERROR: icpx not found. Source the oneAPI compiler environment first." >&2
+    return 1 2>/dev/null || exit 1
+fi
+
+# SYCL-TLA / CUTLASS headers
+: "${SYCL_TLA_DIR:=""}"
+if [ -z "$SYCL_TLA_DIR" ] || [ ! -d "$SYCL_TLA_DIR" ]; then
+    echo "WARNING: SYCL_TLA_DIR not set or not found. Set it to your sycl-tla checkout." >&2
+else
+    _compiler_inc="$(dirname "$(command -v icpx)")/../include"
+    export AIBENCH_SYCL_INCLUDE="${SYCL_TLA_DIR}/include:${SYCL_TLA_DIR}/tools/util/include:${SYCL_TLA_DIR}/examples/common:${_compiler_inc}/sycl:${_compiler_inc}"
+fi
+
+export AIBENCH_SYCL_COMPILER=icpx
+
+echo "SYCL env ready  (icpx: $(icpx --version 2>&1 | head -1))"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,16 +22,20 @@ class TestBackendEnum:
         assert ai_hc.Backend.TRITON == "triton"
         assert ai_hc.Backend.HELION == "helion"
         assert ai_hc.Backend.MLIR == "mlir"
+        assert ai_hc.Backend.GLUON == "gluon"
+        assert ai_hc.Backend.SYCL == "sycl"
 
     def test_backend_iteration(self):
         """Test that all backends can be iterated."""
         backends = list(ai_hc.Backend)
-        assert len(backends) == 5
+        assert len(backends) == 7
         assert ai_hc.Backend.PYTORCH in backends
         assert ai_hc.Backend.PYTORCH_COMPILE in backends
         assert ai_hc.Backend.TRITON in backends
         assert ai_hc.Backend.HELION in backends
         assert ai_hc.Backend.MLIR in backends
+        assert ai_hc.Backend.GLUON in backends
+        assert ai_hc.Backend.SYCL in backends
 
     def test_backend_from_string(self):
         """Test creating backend from string."""
@@ -40,6 +44,8 @@ class TestBackendEnum:
         assert ai_hc.Backend("triton") == ai_hc.Backend.TRITON
         assert ai_hc.Backend("helion") == ai_hc.Backend.HELION
         assert ai_hc.Backend("mlir") == ai_hc.Backend.MLIR
+        assert ai_hc.Backend("gluon") == ai_hc.Backend.GLUON
+        assert ai_hc.Backend("sycl") == ai_hc.Backend.SYCL
 
     def test_backend_invalid_string(self):
         """Test that invalid string raises error."""
@@ -236,6 +242,34 @@ class TestKernelBenchRunnerInit:
 
         assert kb_runner.backend == ai_hc.Backend.MLIR
         assert "mlir" in str(kb_runner.kernels)
+
+    @mock.patch("os.path.isdir")
+    def test_init_gluon_backend(self, mock_isdir):
+        """Test runner initialization with Gluon backend."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            spec_type=ai_hc.SpecKey.V_CI,
+            device=torch.device("cpu"),
+            backend=ai_hc.Backend.GLUON,
+        )
+
+        assert kb_runner.backend == ai_hc.Backend.GLUON
+        assert "gluon" in str(kb_runner.kernels)
+
+    @mock.patch("os.path.isdir")
+    def test_init_sycl_backend(self, mock_isdir):
+        """Test runner initialization with SYCL backend."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            spec_type=ai_hc.SpecKey.V_CI,
+            device=torch.device("cpu"),
+            backend=ai_hc.Backend.SYCL,
+        )
+
+        assert kb_runner.backend == ai_hc.Backend.SYCL
+        assert "sycl" in str(kb_runner.kernels)
 
     @mock.patch("os.path.isdir")
     def test_init_missing_kernels_dir(self, mock_isdir):


### PR DESCRIPTION
- Add Backend.GLUON and Backend.SYCL enum members, path resolvers, CLI flags, and directory routing
- Add SYCL native compilation module (ai_bench/sycl/compiler.py) that compiles and runs C++ CUTLASS kernels via icpx
- Add env_sycl.sh helper for SYCL environment setup
- Add CUTLASS SYCL GEMM kernel for KernelBench level1/matmul
- Gluon kernel directory is a placeholder (.gitkeep) — the Gluon Intel XPU API (triton.experimental.gluon.language.intel.xe) is under active development on intel-xpu-backend-for-triton mdziado/gluon branch and not yet stable. Real Gluon DPAS kernels will be added in a follow-up PR once the API is merged
