### PR TITLE
[harness] Triton CPU backend

### DIFF
--- a/.github/workflows/kernel_bench.yml
+++ b/.github/workflows/kernel_bench.yml
@@ -60,6 +60,18 @@ jobs:
         run: "${{ env.SRUN }} --partition=emr --time=0:15:00 --constraint=\"notrb\" -- \
             '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b torch'"
 
+  CPU-Triton:
+    runs-on: pcl-tiergarten
+    if: |
+      (github.event_name == 'workflow_dispatch' && inputs.DEVICE_CPU && inputs.BACKEND_TRITON)
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Intel Emerald Rapids
+        run: "${{ env.SRUN }} --partition=emr --time=0:30:00 --constraint=\"notrb\" -- \
+            '${{ github.workspace }}/infra/scripts/ci-cpu-run-kernel-bench.sh -m ${{ inputs.RUN_MODE }} -b triton'"
+
   CPU-MLIR:
     runs-on: pcl-tiergarten
     if: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A benchmarking framework for evaluating AI kernel implementations across multipl
 
 | | PyTorch | Triton | Helion | MLIR | Gluon | SYCL |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **CPU** | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **CPU** | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
 | **XPU** | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | **CUDA** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 
@@ -37,6 +37,9 @@ uv sync --extra xpu
 # CPU + CUDA
 uv sync --extra cuda
 
+# CPU + Triton-CPU backend (builds Triton from source)
+uv sync --extra cpu --extra triton-cpu
+
 # CPU + MLIR backend
 uv sync --extra cpu --extra mlir
 ```
@@ -53,6 +56,9 @@ ai-bench --help
 
 # PyTorch on CPU (default)
 ai-bench
+
+# Triton on CPU
+ai-bench --triton
 
 # MLIR on CPU
 ai-bench --mlir

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+import os
 from pathlib import Path
 import types
 
@@ -83,6 +84,20 @@ class KernelRunner:
         else:
             self.warmup = 25
             self.rep = 100
+
+        # Configure Triton backend.
+        #
+        # Torch inductor initializes Triton defaulting to CUDA whenever it is available.
+        # This can throw exception due to lacking CUDA support when Triton CPU is used.
+        # Thus, it is easiest to always configure Triton backend even if it is not actively used.
+        if self.is_cpu():
+            # It might be better to use Triton driver directly instead of env var.
+            # However, current coupling with tests prevents import of the triton module.
+            # TODO: Switch to direct call triton.runtime.driver.set_active_to_cpu()
+            os.environ["TRITON_CPU_BACKEND"] = "1"
+        else:
+            # Disable CPU backend - use default accelerator.
+            os.environ["TRITON_CPU_BACKEND"] = "0"
 
     def is_torch_backend(self) -> bool:
         """Check if the backend is a torch variant.

--- a/backends/triton/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/triton/cpu/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -1,0 +1,93 @@
+# ruff: noqa: E731
+# Example Triton CPU kernel
+# Status: Experimental / uncurated
+# Expectation: Correctness-first, performance not representative
+
+import torch
+import torch.nn as nn
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 32}),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64}),
+    ],
+    key=["M", "N", "K"],  # autotune per problem size
+)
+@triton.jit
+def _matmul_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    a_desc = tl.make_tensor_descriptor(
+        base=a_ptr, shape=(M, K), strides=(K, 1), block_shape=(BLOCK_M, BLOCK_K)
+    )
+    b_desc = tl.make_tensor_descriptor(
+        base=b_ptr, shape=(K, N), strides=(N, 1), block_shape=(BLOCK_K, BLOCK_N)
+    )
+    c_desc = tl.make_tensor_descriptor(
+        base=c_ptr, shape=(M, N), strides=(N, 1), block_shape=(BLOCK_M, BLOCK_N)
+    )
+
+    m = tl.program_id(0) * BLOCK_M
+    n = tl.program_id(1) * BLOCK_N
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, K, BLOCK_K):
+        a = a_desc.load((m, k))
+        b = b_desc.load((k, n))
+        acc = tl.dot(a, b, acc)
+
+    c_desc.store((m, n), acc)
+
+
+def _kernel_function_cpu(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+    assert isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor)
+    assert A.device.type == "cpu" and B.device.type == "cpu", "A and B must be on CPU"
+    assert A.is_floating_point() and B.is_floating_point(), (
+        "A and B must be floating point tensors"
+    )
+    assert A.dtype == B.dtype, f"dtype mismatch: {A.dtype} vs {B.dtype}"
+
+    orig_dtype = A.dtype
+
+    M, K = A.shape
+    K2, N = B.shape
+    assert K == K2, f"Incompatible K dimensions: {K} vs {K2}"
+
+    C32 = torch.empty((M, N), device=A.device, dtype=torch.float32)
+
+    # Autotuned grid: depends on BLOCK_M/BLOCK_N chosen by config
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+
+    _matmul_kernel[grid](
+        A,
+        B,
+        C32,
+        M,
+        N,
+        K,
+    )
+
+    return C32.to(orig_dtype)
+
+
+class Model(nn.Module):
+    """KernelBench-compatible wrapper"""
+
+    def __init__(self, *args, **kwargs):
+        super(Model, self).__init__()
+
+    def forward(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+        return _kernel_function_cpu(A, B)

--- a/infra/scripts/ci-cpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-cpu-run-kernel-bench.sh
@@ -9,6 +9,7 @@ SCRIPTS_DIR=$(realpath $(dirname $0))
 # Backends
 BENCH_BACKEND_TORCH="torch"
 BENCH_BACKEND_TORCH_COMPILE="torch-compile"
+BENCH_BACKEND_TRITON="triton"
 BENCH_BACKEND_MLIR="mlir"
 
 # Run modes
@@ -16,7 +17,7 @@ RUN_MODE_BENCH="bench"
 RUN_MODE_CI="ci"
 
 die_syntax() {
-  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_MLIR})] [-m (${RUN_MODE_BENCH}|${RUN_MODE_CI})]"
+  echo "Syntax: $0 [-b (${BENCH_BACKEND_TORCH}|${BENCH_BACKEND_TORCH_COMPILE}|${BENCH_BACKEND_TRITON}|${BENCH_BACKEND_MLIR})] [-m (${RUN_MODE_BENCH}|${RUN_MODE_CI})]"
   echo ""
   echo "  -b: Optional, backend to use (default: torch)"
   echo "  -m: Optional, run mode to use (default: bench)"
@@ -32,6 +33,7 @@ while getopts "b:m:" arg; do
     b)
       if [ "${OPTARG}" == "${BENCH_BACKEND_TORCH}" ] || \
          [ "${OPTARG}" == "${BENCH_BACKEND_TORCH_COMPILE}" ] || \
+         [ "${OPTARG}" == "${BENCH_BACKEND_TRITON}" ] || \
          [ "${OPTARG}" == "${BENCH_BACKEND_MLIR}" ]; then
         BENCH_BACKEND="${OPTARG}"
       else
@@ -73,6 +75,9 @@ pip install --upgrade --user uv
 AI_BENCH_UV=${HOME}/.local/bin/uv
 
 PROJECT_DEPS="--extra cpu"
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TRITON}" ]]; then
+  PROJECT_DEPS="${PROJECT_DEPS} --extra triton-cpu"
+fi
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_MLIR}" ]]; then
   PROJECT_DEPS="${PROJECT_DEPS} --extra mlir"
 fi
@@ -91,6 +96,9 @@ fi
 
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TORCH_COMPILE}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --torch-compile"
+fi
+if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_TRITON}" ]]; then
+  BENCH_FLAGS="${BENCH_FLAGS} --triton"
 fi
 if [[ "${BENCH_BACKEND}" == "${BENCH_BACKEND_MLIR}" ]]; then
   BENCH_FLAGS="${BENCH_FLAGS} --mlir"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,19 @@ mlir = [
   "lighthouse[ingress_torch_mlir]",
   "ml-dtypes",
 ]
+# If triton-cpu build fails with a stale LLVM path, clear caches:
+#   rm -r ~/.triton/llvm
+#   rm -r ~/.cache/uv/git-v0/checkouts/*/[triton rev hash]/build
+triton-cpu = [
+  "triton",
+  # Extra build dependencies from triton-cpu requirements.txt.
+  "setuptools>=40.8.0",
+  "wheel",
+  "cmake>=3.20,<4.0",
+  "ninja>=1.11.1",
+  "pybind11>=2.13.1",
+  "lit",
+]
 
 [dependency-groups]
 dev = [
@@ -81,10 +94,17 @@ python_functions = ["test_*"]
 
 [tool.uv]
 conflicts = [
+  # Restrict to one device to avoid incompatible dependencies.
   [
     { extra = "cpu" },
     { extra = "xpu" },
     { extra = "cuda" },
+  ],
+  # Set as conflict to ensure correct Triton dependency is chosen between devices.
+  [
+    { extra = "xpu" },
+    { extra = "cuda" },
+    { extra = "triton-cpu" },
   ],
 ]
 override-dependencies = [
@@ -95,6 +115,7 @@ override-dependencies = [
 torch = { index = "pytorch" }
 pytorch-triton-xpu = { index = "pytorch" }
 pytorch-triton = { index = "pytorch" }
+triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "270e696" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "456475d" }
 mlir-python-bindings = { index = "eudsl" }
 


### PR DESCRIPTION
Adds support for running Triton on CPU.

Note: the Triton-CPU backend is pulled from its upstream development branch and built from source. Due to build time, it is not enabled by default with other CPU dependencies but remains opt-in using: '--extra triton-cpu' flag.

Co-authored-by: Julian Oppermann <julian.oppermann@intel.com>