### PR TITLE
[harness] Invoke models directly

### DIFF
--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -304,10 +304,8 @@ def benchmark_problem(
 
                     # Run both kernels
                     with torch.no_grad():
-                        pytorch_fn = pytorch_model.forward
-                        pytorch_output = pytorch_fn(*inputs_orig)
-                        cur_fn = model.forward
-                        cur_output = cur_fn(*inputs_cur)
+                        pytorch_output = pytorch_model(*inputs_orig)
+                        cur_output = model(*inputs_cur)
 
                     # Resolve tolerances: CLI override > spec value > default
                     effective_rtol = (


### PR DESCRIPTION
Modifies numerical comparison check to invoke models directly.
This aligns compare driver calling convention with kernel runner.

Calling kernel models directly ensures all registered hooks, like torch.compile, are called which might influence produced results.