### PR TITLE
Bump PyTorch dependencies

### DIFF
--- a/ai_bench/harness/testing/timer.py
+++ b/ai_bench/harness/testing/timer.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+import os
+import warnings
 
 import torch
 from torch.profiler import ProfilerActivity
@@ -16,10 +18,19 @@ def time_cpu(fn: Callable, args: tuple, warmup: int = 25, rep: int = 100) -> flo
     Returns:
         Mean runtime in microseconds
     """
+    # Supress profiler's warning, no event accumulation is needed.
+    warnings.filterwarnings(
+        "ignore",
+        message="Warning: Profiler clears events",
+        category=UserWarning,
+    )
+    # Supress Kineto logging.
+    os.environ["KINETO_LOG_LEVEL"] = "99"
+
     for _ in range(warmup):
         fn(*args)
 
-    with profile(activities=[ProfilerActivity.CPU]) as prof:
+    with profile(activities=[ProfilerActivity.CPU], acc_events=False) as prof:
         for _ in range(rep):
             with record_function("profiled_fn"):
                 fn(*args)

--- a/ai_bench/mlir/compile.py
+++ b/ai_bench/mlir/compile.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from collections.abc import Sequence
 import os
+import warnings
 
 import lighthouse.ingress.torch.compile as lh_compile
 from mlir import ir
@@ -79,6 +80,7 @@ class CPUBackend(lh_compile.MLIRBackend):
         Returns:
             Callable function.
         """
+        warnings.filterwarnings("ignore", category=FutureWarning)
         jit_func = super().__call__(model, example_inputs)
 
         if os.environ.get("AIBENCH_MLIR_DUMP_OBJ"):

--- a/infra/scripts/ci-cpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-cpu-run-kernel-bench.sh
@@ -66,6 +66,9 @@ THREADS_PER_CORE=$(lscpu | grep --color=never "Thread.*core" | tee - | grep -o "
 SKIP=$((THREADS_PER_CORE-1)) # 0 for no HT, 1 for 2, 3 for 4, etc.
 export KMP_AFFINITY=granularity=fine,compact,$SKIP,0
 echo "KMP_AFFINITY=${KMP_AFFINITY}"
+
+export TRITON_ALWAYS_COMPILE=1
+echo "TRITON_ALWAYS_COMPILE=${TRITON_ALWAYS_COMPILE}"
 echo ""
 
 echo "--- Setup project"

--- a/infra/scripts/ci-cuda-run-kernel-bench.sh
+++ b/infra/scripts/ci-cuda-run-kernel-bench.sh
@@ -61,8 +61,13 @@ done
 # Setup
 echo "--- Setup environment"
 source /swtools/cuda/latest/cuda_vars.sh
+
 PTXAS_PATH=$(which ptxas)
 export TRITON_PTXAS_PATH=${PTXAS_PATH}
+echo "TRITON_PTXAS_PATH=${TRITON_PTXAS_PATH}"
+
+export TRITON_ALWAYS_COMPILE=1
+echo "TRITON_ALWAYS_COMPILE=${TRITON_ALWAYS_COMPILE}"
 echo ""
 
 echo "--- Setup project"

--- a/infra/scripts/ci-cuda-run-kernel-bench.sh
+++ b/infra/scripts/ci-cuda-run-kernel-bench.sh
@@ -61,6 +61,8 @@ done
 # Setup
 echo "--- Setup environment"
 source /swtools/cuda/latest/cuda_vars.sh
+PTXAS_PATH=$(which ptxas)
+export TRITON_PTXAS_PATH=${PTXAS_PATH}
 echo ""
 
 echo "--- Setup project"

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -60,6 +60,9 @@ done
 # Setup
 echo "--- Setup environment"
 source /swtools/intel-gpu/latest/intel_gpu_vars.sh
+
+export TRITON_ALWAYS_COMPILE=1
+echo "TRITON_ALWAYS_COMPILE=${TRITON_ALWAYS_COMPILE}"
 echo ""
 
 echo "--- Setup project"

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -59,7 +59,7 @@ done
 
 # Setup
 echo "--- Setup environment"
-source /swtools/intel/2025.2.0/setvars.sh --force
+source /swtools/intel/setvars.sh
 source /swtools/intel-gpu/latest/intel_gpu_vars.sh
 echo ""
 

--- a/infra/scripts/ci-xpu-run-kernel-bench.sh
+++ b/infra/scripts/ci-xpu-run-kernel-bench.sh
@@ -59,7 +59,6 @@ done
 
 # Setup
 echo "--- Setup environment"
-source /swtools/intel/setvars.sh
 source /swtools/intel-gpu/latest/intel_gpu_vars.sh
 echo ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,16 @@ Repository = "https://github.com/libxsmm/AI-bench"
 
 [project.optional-dependencies]
 cpu = [
-  "torch==2.12.0+cpu",
+  "torch==2.11.0+cpu",
 ]
 xpu = [
-  "torch==2.12.0+xpu",
+  "torch==2.11.0+xpu",
   "pytorch-triton-xpu",
   "helion==1.1.0",
 ]
 cuda = [
-  "torch==2.12.0+cu130",
-  "torchvision==0.27.0",
+  "torch==2.11.0+cu130",
+  "torchvision==0.26.0",
   "pytorch-triton",
   "helion==1.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,15 +47,15 @@ Repository = "https://github.com/libxsmm/AI-bench"
 
 [project.optional-dependencies]
 cpu = [
-  "torch==2.12.0+cpu",
+  "torch==2.12.1+cpu",
 ]
 xpu = [
-  "torch==2.12.0+xpu",
+  "torch==2.12.1+xpu",
   "helion==1.1.0",
 ]
 cuda = [
-  "torch==2.12.0+cu130",
-  "torchvision==0.27.0",
+  "torch==2.12.1+cu130",
+  "torchvision==0.27.1",
   "helion==1.1.0",
 ]
 mlir = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,18 +47,18 @@ Repository = "https://github.com/libxsmm/AI-bench"
 
 [project.optional-dependencies]
 cpu = [
-  "torch==2.9.1+cpu",
+  "torch==2.12.0+cpu",
 ]
 xpu = [
-  "torch==2.9.1+xpu",
+  "torch==2.12.0+xpu",
   "pytorch-triton-xpu",
-  "helion==1.0.0",
+  "helion==1.1.0",
 ]
 cuda = [
-  "torch==2.9.1+cu128",
-  "torchvision==0.24.1",
+  "torch==2.12.0+cu130",
+  "torchvision==0.27.0",
   "pytorch-triton",
-  "helion==1.0.0",
+  "helion==1.1.0",
 ]
 mlir = [
   "lighthouse[ingress_torch_mlir]",
@@ -93,6 +93,7 @@ python_files = ["test_*.py"]
 python_functions = ["test_*"]
 
 [tool.uv]
+index-strategy = "unsafe-best-match"
 conflicts = [
   # Restrict to one device to avoid incompatible dependencies.
   [
@@ -122,7 +123,6 @@ mlir-python-bindings = { index = "eudsl" }
 [[tool.uv.index]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl"
-explicit = true
 
 [[tool.uv.index]]
 name = "eudsl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,16 @@ Repository = "https://github.com/libxsmm/AI-bench"
 
 [project.optional-dependencies]
 cpu = [
-  "torch==2.11.0+cpu",
+  "torch==2.12.0+cpu",
 ]
 xpu = [
-  "torch==2.11.0+xpu",
+  "torch==2.12.0+xpu",
   "pytorch-triton-xpu",
   "helion==1.1.0",
 ]
 cuda = [
-  "torch==2.11.0+cu130",
-  "torchvision==0.26.0",
+  "torch==2.12.0+cu130",
+  "torchvision==0.27.0",
   "pytorch-triton",
   "helion==1.1.0",
 ]
@@ -115,7 +115,7 @@ override-dependencies = [
 [tool.uv.sources]
 torch = { index = "pytorch" }
 pytorch-triton-xpu = { index = "pytorch-xpu" }
-pytorch-triton = { index = "pytorch" }
+pytorch-triton = { index = "pytorch-cuda" }
 triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "eece2e9" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "cccc0f3" }
 mlir-python-bindings = { index = "eudsl" }
@@ -127,6 +127,10 @@ url = "https://download.pytorch.org/whl"
 [[tool.uv.index]]
 name = "pytorch-xpu"
 url = "https://download.pytorch.org/whl/xpu"
+
+[[tool.uv.index]]
+name = "pytorch-cuda"
+url = "https://download.pytorch.org/whl"
 
 [[tool.uv.index]]
 name = "eudsl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-pytorch-triton-xpu = { index = "pytorch" }
+pytorch-triton-xpu = { index = "pytorch-xpu" }
 pytorch-triton = { index = "pytorch" }
 triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "eece2e9" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "cccc0f3" }
@@ -123,6 +123,10 @@ mlir-python-bindings = { index = "eudsl" }
 [[tool.uv.index]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl"
+
+[[tool.uv.index]]
+name = "pytorch-xpu"
+url = "https://download.pytorch.org/whl/xpu"
 
 [[tool.uv.index]]
 name = "eudsl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,11 @@ cpu = [
 ]
 xpu = [
   "torch==2.12.0+xpu",
-  "pytorch-triton-xpu",
   "helion==1.1.0",
 ]
 cuda = [
   "torch==2.12.0+cu130",
   "torchvision==0.27.0",
-  "pytorch-triton",
   "helion==1.1.0",
 ]
 mlir = [
@@ -114,22 +112,12 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-pytorch-triton-xpu = { index = "pytorch-xpu" }
-pytorch-triton = { index = "pytorch-cuda" }
 triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "eece2e9" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "cccc0f3" }
 mlir-python-bindings = { index = "eudsl" }
 
 [[tool.uv.index]]
 name = "pytorch"
-url = "https://download.pytorch.org/whl"
-
-[[tool.uv.index]]
-name = "pytorch-xpu"
-url = "https://download.pytorch.org/whl/xpu"
-
-[[tool.uv.index]]
-name = "pytorch-cuda"
 url = "https://download.pytorch.org/whl"
 
 [[tool.uv.index]]


### PR DESCRIPTION
- Bump to 2.12.1 PyTorch release
- Remove pytorch-triton package - PyTorch triton distribution has been renamed to triton as of 2.10; now triton gets installed automatically for CUDA and XPU
- Suppress external warnings and debug msgs
- Source only Intel GPU vars - the other SYCL dependencies are shipped with the python package, this setup avoids conflicts in the shared libs
- Force Triton to always compile - avoids problems with stale cache and ensures results are up to date on CI runs