### PR TITLE
pytest - ignore future and deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,11 @@ dev = [
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
+filterwarnings = [
+    'error',
+    'ignore::DeprecationWarning',
+    'ignore::FutureWarning',
+]
 
 [tool.uv]
 index-strategy = "unsafe-best-match"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 filterwarnings = [
-    'error',
+    'error', # Turn all uncaptured warnings into errors.
     'ignore::DeprecationWarning',
     'ignore::FutureWarning',
 ]


### PR DESCRIPTION
Configures pytest to ignore irrelevant warnings produced by external libraries.