### PR TITLE
Use `torch.no_grad()`, `model.eval()` and freeze models

### DIFF
--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -302,7 +302,7 @@ def benchmark_problem(
                     inputs_orig = [inp.clone() for inp in inputs]
                     inputs_cur = [inp.clone() for inp in inputs]
 
-                    # Run both kernels.
+                    # Run both kernels
                     with torch.no_grad():
                         pytorch_output = pytorch_model(*inputs_orig)
                         cur_output = model(*inputs_cur)

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -7,6 +7,7 @@ from typing import List
 from typing import Optional
 
 import torch
+import torch._inductor.config as inductor_config
 
 from ai_bench.harness import core as ai_hc
 from ai_bench.harness.runner import KernelBenchRunner
@@ -302,8 +303,8 @@ def benchmark_problem(
                     inputs_orig = [inp.clone() for inp in inputs]
                     inputs_cur = [inp.clone() for inp in inputs]
 
-                    # Run both kernels
-                    with torch.no_grad():
+                    # Run both kernels. Enable freezing here as inductor will lazily compile the model now.
+                    with torch.no_grad(), inductor_config.patch({"freezing": True}):
                         pytorch_output = pytorch_model(*inputs_orig)
                         cur_output = model(*inputs_cur)
 

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -7,7 +7,6 @@ from typing import List
 from typing import Optional
 
 import torch
-import torch._inductor.config as inductor_config
 
 from ai_bench.harness import core as ai_hc
 from ai_bench.harness.runner import KernelBenchRunner
@@ -303,8 +302,8 @@ def benchmark_problem(
                     inputs_orig = [inp.clone() for inp in inputs]
                     inputs_cur = [inp.clone() for inp in inputs]
 
-                    # Run both kernels. Enable freezing here as inductor will lazily compile the model now.
-                    with torch.no_grad(), inductor_config.patch({"freezing": True}):
+                    # Run both kernels.
+                    with torch.no_grad():
                         pytorch_output = pytorch_model(*inputs_orig)
                         cur_output = model(*inputs_cur)
 

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import types
 
 import torch
+import torch._inductor.config as inductor_config
 import yaml
 
 from . import config
@@ -243,14 +244,15 @@ class KernelRunner:
         fn = model
 
         # Measure performance.
-        meas_us = testing.time(
-            fn,
-            args,
-            warmup=self.warmup,
-            rep=self.rep,
-            min_cache_nuke_mib=self.min_cache_nuke_mib,
-            device=self.device,
-        )
+        with torch.no_grad(), inductor_config.patch({"freezing": True}):
+            meas_us = testing.time(
+                fn,
+                args,
+                warmup=self.warmup,
+                rep=self.rep,
+                min_cache_nuke_mib=self.min_cache_nuke_mib,
+                device=self.device,
+            )
 
         # Statistics - FLOPs.
         flop = ai_hc.get_flop(variant)
@@ -367,7 +369,8 @@ class KernelRunner:
             # Simple CI run to verify functionality.
             if self.spec_type == ai_hc.SpecKey.V_CI:
                 self.logger.info(f"Validating: {variant}")
-                model(*args)
+                with torch.no_grad(), inductor_config.patch({"freezing": True}):
+                    model(*args)
                 continue
 
             self.logger.info(f"Benchmarking: {variant}")

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -104,6 +104,11 @@ class KernelRunner:
             # Disable CPU backend - use default accelerator.
             os.environ["TRITON_CPU_BACKEND"] = "0"
 
+        # Freezing enables fusion opportunities in inference mode. Enable it by default, unless inductor's env var is
+        # set.
+        if "TORCHINDUCTOR_FREEZING" not in os.environ:
+            inductor_config.freezing = True
+
     def is_torch_backend(self) -> bool:
         """Check if the backend is a torch variant.
         Returns:
@@ -228,7 +233,7 @@ class KernelRunner:
         memory_format = ai_hc.get_variant_memory_format(variant)
         if memory_format is not None:
             model = model.to(memory_format=memory_format)
-        return model
+        return model.eval()
 
     def benchmark_model(self, variant, model, args) -> KernelStats:
         """Gather model's performance.
@@ -244,7 +249,7 @@ class KernelRunner:
         fn = model
 
         # Measure performance.
-        with torch.no_grad(), inductor_config.patch({"freezing": True}):
+        with torch.no_grad():
             meas_us = testing.time(
                 fn,
                 args,
@@ -369,7 +374,7 @@ class KernelRunner:
             # Simple CI run to verify functionality.
             if self.spec_type == ai_hc.SpecKey.V_CI:
                 self.logger.info(f"Validating: {variant}")
-                with torch.no_grad(), inductor_config.patch({"freezing": True}):
+                with torch.no_grad():
                     model(*args)
                 continue
 


### PR DESCRIPTION
Tailor benchmarking more towards inference, by consistently using `torch.no_grad()`, calling `model.eval()` and allowing inductor to treat weights as constants (a.k.a. freezing). For the pytorch-compile backend on CPU, this enables oneDNN post-op fusion and the use of the `TORCHINDUCTOR_MAX_AUTOTUNE=1` mode in which a custom fused GEMM is generated from a C++/OpenMP template.