### PR TITLE
Introduce env vars to override warmup/timed iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ Environment variables used for project configuration:
 | `AIBENCH_SYCL_COMPILER` | Path to SYCL compiler (default: `icpx`) |
 | `AIBENCH_SYCL_INCLUDE` | Colon-separated include paths for CUTLASS/SYCL headers |
 | `AIBENCH_SYCL_FLAGS` | Extra compiler flags (space-separated) |
+| `AIBENCH_WARMUP` | Override number of warmup iterations |
+| `AIBENCH_REP` | Override number of timed iterations |
 | `AIBENCH_CPU_MIN_CACHE_NUKE_MIB` | Minimum memory size (in MiB) for a cache-nuking GEMM between timed iterations on CPU |
 
 ## License

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -90,6 +90,11 @@ class KernelRunner:
             self.warmup = 25
             self.rep = 100
 
+        if "AIBENCH_WARMUP" in os.environ:
+            self.warmup = int(os.environ["AIBENCH_WARMUP"])
+        if "AIBENCH_REP" in os.environ:
+            self.rep = int(os.environ["AIBENCH_REP"])
+
         # Configure Triton backend.
         #
         # Torch inductor initializes Triton defaulting to CUDA whenever it is available.


### PR DESCRIPTION
I often find myself adjusting these locally.