### PR TITLE
Bump Triton CPU and its dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ triton-cpu = [
   "wheel",
   "cmake>=3.20,<4.0",
   "ninja>=1.11.1",
-  "pybind11>=2.13.1",
+  "nanobind==2.10.2",
   "lit",
 ]
 
@@ -118,7 +118,7 @@ override-dependencies = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "3c0ed95" }
+triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "9439797" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "6f14f3a" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }


### PR DESCRIPTION
Upstream Triton switched to `nanobind`.