### PR TITLE
[Specs] Allow multiple `dims` selection

### DIFF
--- a/ai_bench/harness/core/__init__.py
+++ b/ai_bench/harness/core/__init__.py
@@ -6,6 +6,7 @@ from .specs import InKey
 from .specs import SpecKey
 from .specs import VKey
 from .specs import apply_input_inits
+from .specs import expand_variants
 from .specs import get_atol
 from .specs import get_flop
 from .specs import get_inits
@@ -31,6 +32,7 @@ __all__ = [
     "SpecKey",
     "VKey",
     "apply_input_inits",
+    "expand_variants",
     "get_atol",
     "get_flop",
     "get_inits",

--- a/ai_bench/harness/core/specs.py
+++ b/ai_bench/harness/core/specs.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     from strenum import StrEnum
 
+import copy
 from functools import cache
 from typing import Dict
 
@@ -311,6 +312,32 @@ def get_inits(variant: dict, inits: list[dict]) -> list[object]:
         else:
             raise ValueError("Unsupported init value")
     return init_vals
+
+
+def expand_variants(variants: list[dict]) -> list[dict]:
+    """Expand variants whose 'dims' is a list of dim mappings.
+
+    A variant may declare 'dims' as a list of dim mappings to run the same
+    configuration across multiple shapes. Each mapping becomes its own
+    variant, so per-variant formula fields ('flop', 'mem_bytes') are
+    evaluated against each dims option.
+
+    Args:
+        variants: Specs' variant entries
+    Returns:
+        Flattened list of variant entries, each with a single 'dims' mapping
+    """
+    expanded: list[dict] = []
+    for variant in variants:
+        dims = variant.get(VKey.DIMS)
+        if isinstance(dims, list):
+            for dims_option in dims:
+                new_variant = copy.deepcopy(variant)
+                new_variant[VKey.DIMS] = dims_option
+                expanded.append(new_variant)
+        else:
+            expanded.append(variant)
+    return expanded
 
 
 def get_variant_torch_dtype(variant: dict) -> torch.dtype | None:

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -216,7 +216,7 @@ class KernelBenchRunner(KernelRunner):
             f"Kernel: {spec_path.parent.name} / {spec_path.name} [{self.backend}]"
         )
 
-        variants = spec[self.spec_type]
+        variants = ai_hc.expand_variants(spec[self.spec_type])
         stats = []
         for variant in variants:
             dims = variant.get("dims", {})

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -196,7 +196,7 @@ class KernelRunner:
         Returns:
             Defined spec type variants
         """
-        return spec[self.spec_type]
+        return ai_hc.expand_variants(spec[self.spec_type])
 
     def get_spec_inputs(self, spec: dict) -> dict:
         """Get problem inputs.

--- a/docs/problem_spec.md
+++ b/docs/problem_spec.md
@@ -135,7 +135,7 @@ bench-gpu:
 |---|---|---|---|
 | `params` | yes | list of input names | Which declared `inputs` to build and pass to the kernel, in order. |
 | `dtype` | no* | string | Torch dtype name applied to the model/inputs. Required unless every input using it has an explicit (non-`inherit`) `dtype` of its own. |
-| `dims` | yes | mapping | Concrete size for every dim name used by this variant's inputs/inits. Values are numbers, booleans, or lists of numbers (for shape-valued dims like `BIAS_SHAPE: [32, 1, 1]`). |
+| `dims` | yes | mapping | Concrete size for every dim name used by this variant's inputs/inits. Values are numbers, booleans, or lists of numbers (for shape-valued dims like `BIAS_SHAPE: [32, 1, 1]`). May also be a list of such mappings to expand the variant across several shapes (see [Expanding dims](#expanding-dims)). |
 | `flop` | no | number or formula string | FLOP count, or a formula over `dims` (e.g. `"2*BATCH*N*N"`). Estimated automatically if omitted (PyTorch backend only). |
 | `mem_bytes` | no | number or formula string | Memory traffic in bytes, or a formula over `dims`. Estimated automatically if omitted (PyTorch backend only). |
 | `rtol` | no | number | Relative tolerance override for correctness checks. Default: `1e-2`. |
@@ -154,6 +154,29 @@ mem_bytes: "(M*K + K*N + M*N) * 4" # f32
 ```
 
 Supported operators: `+ - * / **`. No function calls.
+
+### Expanding dims
+
+To run one variant across several shapes without repeating the whole entry,
+set `dims` to a list of mappings. Each mapping is expanded into its own
+variant, and per-variant formula fields (`flop`, `mem_bytes`) are evaluated
+against each option:
+
+```yaml
+bench-gpu:
+  - params: [A, B]
+    dtype: float16
+    dims:
+      - N: 1024
+      - N: 2048
+      - N: 4096
+    flop: "2*N*N*N"
+    rtol: 1.0e-03
+    atol: 1.0e-05
+```
+
+This is equivalent to writing three separate variants that share the same
+`params`, `dtype`, `flop`, and tolerances but differ in `N`.
 
 ## Tips
 

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -22,7 +22,9 @@ bench-cpu:
   - params: [A, B]
     dtype: bfloat16
     dims:
-      N: 4096
+      - N: 1024
+      - N: 2048
+      - N: 4096
     atol: 1
     flop: "2*N*N*N"
 
@@ -30,21 +32,9 @@ bench-gpu:
   - params: [A, B]
     dtype: float16
     dims:
-      N: 1024
-    flop: "2*N*N*N"
-    rtol: 1.0e-03
-    atol: 1.0e-05
-  - params: [A, B]
-    dtype: float16
-    dims:
-      N: 2048
-    flop: "2*N*N*N"
-    rtol: 1.0e-03
-    atol: 1.0e-05
-  - params: [A, B]
-    dtype: float16
-    dims:
-      N: 4096
+      - N: 1024
+      - N: 2048
+      - N: 4096
     flop: "2*N*N*N"
     rtol: 1.0e-03
     atol: 1.0e-05

--- a/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/2_Standard_matrix_multiplication_.yaml
@@ -26,9 +26,12 @@ bench-cpu:
   - params: [A, B]
     dtype: bfloat16
     dims:
-      M: 3072
+    - M: 3072
       N: 3072
       K: 4096
+    - M: 2048
+      N: 2048
+      K: 8192
     atol: 1
     flop: "2*M*N*K"
     mem_bytes: "(M*K + K*N + M*N) * 2" # bf16

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -387,5 +387,105 @@ class TestMemoryFormat:
             )
 
 
+class TestExpandVariants:
+    """Tests for expanding variants with a list of dims."""
+
+    def test_expands_list_of_dims(self):
+        """Test a variant with a list of dims expands into one variant each."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["A", "B"],
+            ai_hc.VKey.TYPE: "float16",
+            ai_hc.VKey.DIMS: [{"N": 1024}, {"N": 2048}, {"N": 4096}],
+            ai_hc.VKey.FLOP: "2*N*N*N",
+            ai_hc.VKey.MEM_BYTES: "2*N*N",
+            ai_hc.VKey.RTOL: 1.0e-03,
+            ai_hc.VKey.ATOL: 1.0e-05,
+        }
+
+        expanded = ai_hc.expand_variants([variant])
+
+        assert len(expanded) == 3
+        assert [v[ai_hc.VKey.DIMS] for v in expanded] == [
+            {"N": 1024},
+            {"N": 2048},
+            {"N": 4096},
+        ]
+        # Shared fields are preserved on every expanded variant.
+        for v in expanded:
+            assert v[ai_hc.VKey.PARAMS] == ["A", "B"]
+            assert v[ai_hc.VKey.TYPE] == "float16"
+            assert v[ai_hc.VKey.RTOL] == 1.0e-03
+            assert v[ai_hc.VKey.ATOL] == 1.0e-05
+
+        # Formula fields are evaluated per dims option.
+        assert [ai_hc.get_flop(v) for v in expanded] == [
+            2 * 1024**3,
+            2 * 2048**3,
+            2 * 4096**3,
+        ]
+        assert [ai_hc.get_mem_bytes(v) for v in expanded] == [
+            2 * 1024**2,
+            2 * 2048**2,
+            2 * 4096**2,
+        ]
+
+    def test_mapping_dims_unchanged(self):
+        """Test a variant with a plain dims mapping is passed through as-is."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["A"],
+            ai_hc.VKey.DIMS: {"N": 128},
+        }
+
+        expanded = ai_hc.expand_variants([variant])
+
+        assert expanded == [variant]
+
+    def test_shape_valued_dim_not_expanded(self):
+        """Test list-valued dims (shapes) do not trigger expansion."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["X"],
+            ai_hc.VKey.DIMS: {"BIAS_SHAPE": [32, 1, 1], "N": 64},
+        }
+
+        expanded = ai_hc.expand_variants([variant])
+
+        assert len(expanded) == 1
+        assert expanded[0][ai_hc.VKey.DIMS] == {"BIAS_SHAPE": [32, 1, 1], "N": 64}
+
+    def test_mixed_variants(self):
+        """Test a list mixing expandable and plain variants."""
+        list_variant = {
+            ai_hc.VKey.PARAMS: ["A"],
+            ai_hc.VKey.DIMS: [{"N": 16}, {"N": 32}],
+        }
+        plain_variant = {
+            ai_hc.VKey.PARAMS: ["A"],
+            ai_hc.VKey.DIMS: {"N": 64},
+        }
+
+        expanded = ai_hc.expand_variants([list_variant, plain_variant])
+
+        assert len(expanded) == 3
+        assert [v[ai_hc.VKey.DIMS] for v in expanded] == [
+            {"N": 16},
+            {"N": 32},
+            {"N": 64},
+        ]
+
+    def test_expansion_is_deep_copied(self):
+        """Test expanded variants are independent copies of the source."""
+        variant = {
+            ai_hc.VKey.PARAMS: ["A"],
+            ai_hc.VKey.DIMS: [{"N": 16}, {"N": 32}],
+        }
+
+        expanded = ai_hc.expand_variants([variant])
+        expanded[0][ai_hc.VKey.PARAMS].append("B")
+
+        # Mutating one expanded variant must not affect the others or source.
+        assert expanded[1][ai_hc.VKey.PARAMS] == ["A"]
+        assert variant[ai_hc.VKey.PARAMS] == ["A"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Instead of repeating the parameter variants, allow dims to be a list, which appends to the variants to execute in the same way as before, but with a lower chance of copy-pasta.

Preparing this to enable wider testing on kernels though Lighthouse for the various shapes and thread options.

Assisted by: Claude