### PR TITLE
[CLI] Benchmark a custom variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ ai-bench --xpu --sycl
 # Benchmark mode (with timing)
 ai-bench --xpu --bench
 
+# Benchmark a custom spec variant
+ai-bench --variant custom-variant
+
 # Log results to CSV
 ai-bench --xpu --bench --csv results.csv --note "baseline run"
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -41,6 +41,9 @@ Examples:
   # Run with MLIR backend
   ai-bench --bench --mlir
 
+  # Benchmark a custom spec variant
+  ai-bench --variant custom-variant
+
   # Save results to CSV
   ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
@@ -210,6 +213,12 @@ Environment file (.env) example:
         default=False,
         help="Run full benchmarks (default: CI validation only)",
     )
+    mode_group.add_argument(
+        "--variant",
+        type=str,
+        default=None,
+        help="Variant name from spec (e.g. bench-gpu-1). Overrides default spec_type selection.",
+    )
 
     # Output options
     output_group = parser.add_argument_group("output options")
@@ -317,6 +326,10 @@ def main(argv: list[str] | None = None) -> int:
             spec_type = core.SpecKey.V_BENCH_GPU
     else:
         spec_type = core.SpecKey.V_CI
+
+    # Override spec type if given
+    if args.variant:
+        spec_type = args.variant
 
     # Determine units
     flops_unit = runner.FlopsUnit.GFLOPS if args.gflops else runner.FlopsUnit.TFLOPS

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -30,7 +30,7 @@ class KernelBenchRunner(KernelRunner):
 
     def __init__(
         self,
-        spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_CI,
+        spec_type: ai_hc.SpecKey | str = ai_hc.SpecKey.V_CI,
         device: torch.device | None = None,
         backend: ai_hc.Backend = ai_hc.Backend.PYTORCH,
         flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -63,7 +63,7 @@ class KernelRunner:
 
     def __init__(
         self,
-        spec_type: ai_hc.SpecKey = ai_hc.SpecKey.V_CI,
+        spec_type: ai_hc.SpecKey | str = ai_hc.SpecKey.V_CI,
         device: torch.device | None = None,
         backend: ai_hc.Backend = ai_hc.Backend.PYTORCH,
         flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,20 @@ class Model(torch.nn.Module):
         return x * 2
 """
 
+# Spec exposing a custom, non-default variant key used to exercise --variant.
+_SPEC_CUSTOM_VARIANT = """
+inputs:
+  X:
+    shape: [N]
+    dtype: float32
+my-variant:
+  - params: [X]
+    dims:
+      N: 8
+    flop: N
+    mem_bytes: N * 4
+"""
+
 
 @pytest.fixture(autouse=True)
 def _reset_finder():
@@ -84,6 +98,7 @@ class TestCreateParser:
         assert args.no_env is False
         assert args.csv is None
         assert args.note == ""
+        assert args.variant is None
 
     def test_device_group_mutually_exclusive(self):
         """Test that --xpu and --cuda cannot be combined."""
@@ -171,6 +186,24 @@ class TestMainSpecType:
     )
     def test_spec_type(self, mock_kb_runner, argv, expected):
         """Test that --bench and device select the right spec category."""
+        rc = cli.main(argv)
+
+        assert rc == 0
+        assert mock_kb_runner.call_args.kwargs["spec_type"] == expected
+
+    @pytest.mark.parametrize(
+        "argv, expected",
+        [
+            (["--no-env", "--variant", "bench-gpu-1"], "bench-gpu-1"),
+            (["--no-env", "--bench", "--variant", "custom"], "custom"),
+            (
+                ["--no-env", "--bench", "--xpu", "--variant", "my-variant"],
+                "my-variant",
+            ),
+        ],
+    )
+    def test_variant_overrides_spec_type(self, mock_kb_runner, argv, expected):
+        """Test that --variant overrides the default spec-type selection."""
         rc = cli.main(argv)
 
         assert rc == 0
@@ -429,5 +462,25 @@ class TestMainIntegration:
         spec.write_text(_SPEC_CI)
 
         rc = cli.main(["--no-env", "--kernel", str(kernel), str(spec)])
+
+        assert rc == 0
+
+    def test_single_kernel_custom_variant_run(self, tmp_path):
+        """Test that --variant selects and benchmarks a custom spec variant."""
+        kernel = tmp_path / "double.py"
+        kernel.write_text(_KERNEL_DOUBLE)
+        spec = tmp_path / "double.yaml"
+        spec.write_text(_SPEC_CUSTOM_VARIANT)
+
+        rc = cli.main(
+            [
+                "--no-env",
+                "--variant",
+                "my-variant",
+                "--kernel",
+                str(kernel),
+                str(spec),
+            ]
+        )
 
         assert rc == 0


### PR DESCRIPTION
Adds '--variant' flag to 'ai-bench' to allow overriding default spec variant selection.

It aligns options of the two available CLI runners.