### PR TITLE
[harness] Freeze models only for native PyTorch backends

### DIFF
--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -109,9 +109,10 @@ class KernelRunner:
             # Disable CPU backend - use default accelerator.
             os.environ["TRITON_CPU_BACKEND"] = "0"
 
-        # Freezing enables fusion opportunities in inference mode. Enable it by default, unless inductor's env var is
-        # set.
-        if "TORCHINDUCTOR_FREEZING" not in os.environ:
+        # Freezing enables fusion opportunities in inference mode.
+        # Enable it by default for PyTorch backends, unless inductor's env var is set.
+        # It is not enabled for MLIR to avoid large constant materialization.
+        if self.is_torch_backend() and "TORCHINDUCTOR_FREEZING" not in os.environ:
             inductor_config.freezing = True
 
     def is_torch_backend(self) -> bool:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 import pytest
 import torch
+import torch._inductor.config as inductor_config
 
 from ai_bench.harness import core as ai_hc
 from ai_bench.harness import runner
@@ -336,6 +337,50 @@ class TestKernelBenchRunnerInit:
 
         assert kb_runner.warmup == 7
         assert kb_runner.rep == 71
+
+    @pytest.mark.parametrize(
+        "backend",
+        [ai_hc.Backend.PYTORCH, ai_hc.Backend.PYTORCH_COMPILE],
+    )
+    @mock.patch("os.path.isdir")
+    def test_freezing_enabled_for_torch_backends(self, mock_isdir, backend):
+        """Test that inductor freezing is enabled for native torch backends."""
+        mock_isdir.return_value = True
+
+        with mock.patch.dict(os.environ, clear=False):
+            os.environ.pop("TORCHINDUCTOR_FREEZING", None)
+            with mock.patch.object(inductor_config, "freezing", False):
+                runner.KernelBenchRunner(
+                    device=torch.device("cpu"),
+                    backend=backend,
+                )
+
+                assert inductor_config.freezing is True
+
+    @pytest.mark.parametrize(
+        "backend",
+        [
+            ai_hc.Backend.MLIR,
+            ai_hc.Backend.TRITON,
+            ai_hc.Backend.HELION,
+            ai_hc.Backend.GLUON,
+            ai_hc.Backend.SYCL,
+        ],
+    )
+    @mock.patch("os.path.isdir")
+    def test_freezing_disabled_for_non_torch_backends(self, mock_isdir, backend):
+        """Test that inductor freezing stays disabled for non-torch backends like MLIR."""
+        mock_isdir.return_value = True
+
+        with mock.patch.dict(os.environ, clear=False):
+            os.environ.pop("TORCHINDUCTOR_FREEZING", None)
+            with mock.patch.object(inductor_config, "freezing", False):
+                runner.KernelBenchRunner(
+                    device=torch.device("cpu"),
+                    backend=backend,
+                )
+
+                assert inductor_config.freezing is False
 
 
 class TestKernelBenchRunnerExecution:


### PR DESCRIPTION
Frozen model allows for more optimization opportunities. However, it creates problems with converting PyTorch model to MLIR.

This change primarily avoids materializing large constants in MLIR as fusion can still be freely performed.