### PR TITLE
[CLI] Validation only run

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ ai-bench --xpu --bench
 # Benchmark a custom spec variant
 ai-bench --variant custom-variant
 
+# Validate a custom spec variant without benchmarking
+ai-bench --variant custom-variant --ci
+
 # Log results to CSV
 ai-bench --xpu --bench --csv results.csv --note "baseline run"
 

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -44,6 +44,9 @@ Examples:
   # Benchmark a custom spec variant
   ai-bench --variant custom-variant
 
+  # Validate a custom spec variant without benchmarking
+  ai-bench --variant custom-variant --ci
+
   # Save results to CSV
   ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
@@ -219,6 +222,12 @@ Environment file (.env) example:
         default=None,
         help="Variant name from spec (e.g. bench-gpu-1). Overrides default spec_type selection.",
     )
+    mode_group.add_argument(
+        "--ci",
+        action="store_true",
+        default=False,
+        help="Force a single validation run instead of benchmarking (works with --variant).",
+    )
 
     # Output options
     output_group = parser.add_argument_group("output options")
@@ -363,6 +372,7 @@ def main(argv: list[str] | None = None) -> int:
                 backend=backend,
                 flops_unit=flops_unit,
                 mem_bw_unit=mem_bw_unit,
+                validate_only=args.ci,
             )
             kernel_runner.run_kernel_spec(kernel_path, spec_path)
             return 0
@@ -376,6 +386,7 @@ def main(argv: list[str] | None = None) -> int:
             mem_bw_unit=mem_bw_unit,
             csv_path=args.csv,
             note=args.note,
+            validate_only=args.ci,
         )
         kb_runner.run_kernels()
         return 0

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -26,6 +26,7 @@ class KernelBenchRunner(KernelRunner):
         flops_unit: FLOPS unit to use for reporting
         csv_path: Path to CSV file for logging (optional)
         note: Optional note to include in CSV
+        validate_only: Force a single validation run instead of benchmarking
     """
 
     def __init__(
@@ -37,6 +38,7 @@ class KernelBenchRunner(KernelRunner):
         mem_bw_unit: config.MemBwUnit = config.MemBwUnit.GBS,
         csv_path: str | None = None,
         note: str = "",
+        validate_only: bool = False,
     ):
         super().__init__(
             spec_type=spec_type,
@@ -44,6 +46,7 @@ class KernelBenchRunner(KernelRunner):
             backend=backend,
             flops_unit=flops_unit,
             mem_bw_unit=mem_bw_unit,
+            validate_only=validate_only,
         )
         self.specs = ai_utils.specs() / "KernelBench"
         self.csv_path = csv_path
@@ -225,7 +228,7 @@ class KernelBenchRunner(KernelRunner):
             k = dims.get("K", m)
             dtype = variant.get(ai_hc.VKey.TYPE)
 
-            is_ci = self.spec_type == ai_hc.SpecKey.V_CI
+            is_ci = self.is_validation_run()
             iterations = 0 if is_ci else 20
 
             self.logger.info(f"{'Validating' if is_ci else 'Benchmarking'}: {variant}")

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -59,6 +59,7 @@ class KernelRunner:
         flops_unit: FLOPS unit to use for reporting
         csv_path: Path to CSV file for logging (optional)
         note: Optional note to include in CSV
+        validate_only: Force a single validation run instead of benchmarking
     """
 
     def __init__(
@@ -68,11 +69,13 @@ class KernelRunner:
         backend: ai_hc.Backend = ai_hc.Backend.PYTORCH,
         flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,
         mem_bw_unit: config.MemBwUnit = config.MemBwUnit.GBS,
+        validate_only: bool = False,
     ):
         self.backend = backend
         self.logger = setup_logger()
         self.flops_unit = flops_unit
         self.mem_bw_unit = mem_bw_unit
+        self.validate_only = validate_only
 
         self.spec_type = spec_type
         self.device = device if device else torch.device("cpu")
@@ -137,6 +140,14 @@ class KernelRunner:
     def is_gpu(self) -> bool:
         """Check if the device is a GPU."""
         return self.is_xpu() or self.is_cuda()
+
+    def is_validation_run(self) -> bool:
+        """Check if the run should validate only, without benchmarking.
+        Returns:
+            True when a single validation run is requested, either via the
+            CI spec type or an explicit validation-only override.
+        """
+        return self.validate_only or self.spec_type == ai_hc.SpecKey.V_CI
 
     def load_model(self, kernel_path: Path) -> types.ModuleType | None:
         """Load a kernel model.
@@ -377,8 +388,8 @@ class KernelRunner:
                 model.compile(dynamic=False)
             args = ai_hc.get_inputs(variant, spec_inputs, device=self.device)
 
-            # Simple CI run to verify functionality.
-            if self.spec_type == ai_hc.SpecKey.V_CI:
+            # Simple validation run to verify functionality.
+            if self.is_validation_run():
                 self.logger.info(f"Validating: {variant}")
                 with torch.no_grad():
                     model(*args)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -382,6 +382,30 @@ class TestKernelBenchRunnerInit:
 
                 assert inductor_config.freezing is False
 
+    @pytest.mark.parametrize(
+        "spec_type, validate_only, expected",
+        [
+            (ai_hc.SpecKey.V_CI, False, True),
+            (ai_hc.SpecKey.V_BENCH_CPU, False, False),
+            ("my-variant", False, False),
+            ("my-variant", True, True),
+            (ai_hc.SpecKey.V_BENCH_CPU, True, True),
+        ],
+    )
+    @mock.patch("os.path.isdir")
+    def test_is_validation_run(self, mock_isdir, spec_type, validate_only, expected):
+        """Test validation-run detection across spec types and --ci override."""
+        mock_isdir.return_value = True
+
+        kb_runner = runner.KernelBenchRunner(
+            spec_type=spec_type,
+            device=torch.device("cpu"),
+            backend=ai_hc.Backend.PYTORCH,
+            validate_only=validate_only,
+        )
+
+        assert kb_runner.is_validation_run() is expected
+
 
 class TestKernelBenchRunnerExecution:
     """Tests for KernelBenchRunner execution with mocked kernels."""
@@ -539,6 +563,92 @@ class Model(torch.nn.Module):
             )
             # Should not raise any exceptions.
             kb_runner.run_kernels()
+
+    def test_validate_only_skips_benchmark(self, temp_dirs):
+        """Test that validate_only forces validation, skipping benchmarking."""
+        spec_content = """
+inputs:
+  X:
+    shape: [N]
+    dtype: float32
+bench-cpu:
+  - params: [X]
+    dims:
+      N: 8
+    flop: N
+    mem_bytes: N * 4
+"""
+        kernel_content = """
+import torch
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x * 2
+"""
+        self._create_spec_file(temp_dirs["specs"], "double.yaml", spec_content)
+        self._create_kernel_file(
+            temp_dirs["pytorch_kernels"], "double.py", kernel_content
+        )
+
+        with mock.patch(
+            "ai_bench.utils.finder.project_root", return_value=temp_dirs["root"]
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_BENCH_CPU,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.PYTORCH,
+                validate_only=True,
+            )
+            with mock.patch.object(kb_runner, "benchmark_model") as mock_bench:
+                kb_runner.run_kernels()
+
+            mock_bench.assert_not_called()
+
+    def test_bench_spec_benchmarks_without_validate_only(self, temp_dirs):
+        """Test that a bench spec benchmarks when validate_only is not set."""
+        spec_content = """
+inputs:
+  X:
+    shape: [N]
+    dtype: float32
+bench-cpu:
+  - params: [X]
+    dims:
+      N: 8
+    flop: N
+    mem_bytes: N * 4
+"""
+        kernel_content = """
+import torch
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return x * 2
+"""
+        self._create_spec_file(temp_dirs["specs"], "double.yaml", spec_content)
+        self._create_kernel_file(
+            temp_dirs["pytorch_kernels"], "double.py", kernel_content
+        )
+
+        with mock.patch(
+            "ai_bench.utils.finder.project_root", return_value=temp_dirs["root"]
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_BENCH_CPU,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.PYTORCH,
+                validate_only=False,
+            )
+            with mock.patch.object(kb_runner, "benchmark_model") as mock_bench:
+                kb_runner.run_kernels()
+
+            mock_bench.assert_called()
 
     def test_run_kernels_different_backends(self, temp_dirs):
         """Test running same spec with different backends."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ class TestCreateParser:
         assert args.csv is None
         assert args.note == ""
         assert args.variant is None
+        assert args.ci is False
 
     def test_device_group_mutually_exclusive(self):
         """Test that --xpu and --cuda cannot be combined."""
@@ -208,6 +209,55 @@ class TestMainSpecType:
 
         assert rc == 0
         assert mock_kb_runner.call_args.kwargs["spec_type"] == expected
+
+
+class TestMainValidateOnly:
+    """Tests for the --ci validation-only override in main()."""
+
+    def test_default_validate_only_false(self, mock_kb_runner):
+        """Test that validate_only defaults to False without --ci."""
+        rc = cli.main(["--no-env"])
+
+        assert rc == 0
+        assert mock_kb_runner.call_args.kwargs["validate_only"] is False
+
+    def test_ci_forwards_validate_only(self, mock_kb_runner):
+        """Test that --ci forces validation-only on the runner."""
+        rc = cli.main(["--no-env", "--ci"])
+
+        assert rc == 0
+        assert mock_kb_runner.call_args.kwargs["validate_only"] is True
+
+    def test_ci_with_variant_forces_validation(self, mock_kb_runner):
+        """Test that --ci validates a custom variant instead of benchmarking."""
+        rc = cli.main(["--no-env", "--variant", "bench-gpu-1", "--ci"])
+
+        assert rc == 0
+        kwargs = mock_kb_runner.call_args.kwargs
+        assert kwargs["spec_type"] == "bench-gpu-1"
+        assert kwargs["validate_only"] is True
+
+    def test_ci_forwards_to_kernel_runner(self, mock_kernel_runner, tmp_path):
+        """Test that --ci forwards validate_only in single-kernel mode."""
+        kernel = tmp_path / "double.py"
+        kernel.write_text(_KERNEL_DOUBLE)
+        spec = tmp_path / "double.yaml"
+        spec.write_text(_SPEC_CUSTOM_VARIANT)
+
+        rc = cli.main(
+            [
+                "--no-env",
+                "--variant",
+                "my-variant",
+                "--ci",
+                "--kernel",
+                str(kernel),
+                str(spec),
+            ]
+        )
+
+        assert rc == 0
+        assert mock_kernel_runner.call_args.kwargs["validate_only"] is True
 
 
 class TestMainUnits:


### PR DESCRIPTION
Adds a '--ci' flag to 'ai-bench' CLI to enforce validation only runs for any variants. This allows quick test runs for any custom specs.