### PR TITLE
[harness][CLI] Run only specified dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ ai-bench --variant custom-variant
 # Validate a custom spec variant without benchmarking
 ai-bench --variant custom-variant --ci
 
+# Run only float32 variants
+ai-bench --bench --dtype float32
+
 # Log results to CSV
 ai-bench --xpu --bench --csv results.csv --note "baseline run"
 
@@ -117,6 +120,9 @@ ai-bench-compare --problem level1/1_Square_matrix_multiplication_
 
 # Compare PyTorch and Triton backends on XPU
 ai-bench-compare --problem level2/99_Matmul_GELU_Softmax --backend pytorch triton --xpu
+
+# Compare only bfloat16 variants
+ai-bench-compare --problem level1/1_Square_matrix_multiplication_ --dtype bfloat16
 ```
 
 Optionally, custom CLI autocompletion is available for certain scripts. It can be activated using:
@@ -214,6 +220,9 @@ Notes legend:
 | `--gluon` | Use Gluon backend (default: PyTorch eager) |
 | `--sycl` | Use SYCL backend (default: PyTorch eager) |
 | `--bench` | Run benchmarks with timing (default: CI validation) |
+| `--ci` | Force a single validation run only for any variant |
+| `--variant VARIANT` | Run only specified spec `VARIANT` |
+| `--dtype DTYPE` | Run only variants with specified `DTYPE` |
 | `--gflops` | Report GFLOPS (default: TFLOPS) |
 | `--mbs` | Report MB/s (default: GB/s) |
 | `--csv PATH` | Log results to specified CSV file |

--- a/ai_bench/cli.py
+++ b/ai_bench/cli.py
@@ -228,6 +228,12 @@ Environment file (.env) example:
         default=False,
         help="Force a single validation run instead of benchmarking (works with --variant).",
     )
+    mode_group.add_argument(
+        "--dtype",
+        type=str,
+        default=None,
+        help="Run only variants with this problem-spec dtype (e.g. float32, int64).",
+    )
 
     # Output options
     output_group = parser.add_argument_group("output options")
@@ -373,6 +379,7 @@ def main(argv: list[str] | None = None) -> int:
                 flops_unit=flops_unit,
                 mem_bw_unit=mem_bw_unit,
                 validate_only=args.ci,
+                dtype=args.dtype,
             )
             kernel_runner.run_kernel_spec(kernel_path, spec_path)
             return 0
@@ -387,6 +394,7 @@ def main(argv: list[str] | None = None) -> int:
             csv_path=args.csv,
             note=args.note,
             validate_only=args.ci,
+            dtype=args.dtype,
         )
         kb_runner.run_kernels()
         return 0

--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -112,6 +112,12 @@ Examples:
         default=None,
         help="Variant name from spec (e.g. bench-gpu-1). Overrides default spec_type selection.",
     )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default=None,
+        help="Run only variants with this problem-spec dtype (e.g. float32, int64).",
+    )
 
     argcomplete.autocomplete(parser)
     return parser
@@ -162,6 +168,7 @@ def main(argv: list[str] | None = None) -> int:
             rtol=args.rtol,
             atol=args.atol,
             backends=backends,
+            dtype=args.dtype,
         )
         (print_comparison_brief if args.brief else print_comparison)(results)
         return 0

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -207,10 +207,11 @@ class VariantResult:
 def benchmark_problem(
     problem: str,
     device: torch.device,
-    spec_type: str = ai_hc.SpecKey.V_BENCH_GPU,
+    spec_type: ai_hc.SpecKey | str = ai_hc.SpecKey.V_BENCH_GPU,
     rtol: float | None = None,
     atol: float | None = None,
     backends: Optional[List[ai_hc.Backend]] = None,
+    dtype: str | None = None,
 ) -> dict:
     """Benchmark a specific problem across multiple backends.
 
@@ -226,6 +227,7 @@ def benchmark_problem(
         rtol: Override relative tolerance. If None, uses per-variant spec value.
         atol: Override absolute tolerance. If None, uses per-variant spec value.
         backends: List of backends to benchmark
+        dtype: Run only variants whose problem-spec dtype matches this value.
     Returns:
         Dictionary with benchmark results
     """
@@ -268,7 +270,10 @@ def benchmark_problem(
             logger.info(f"backend: {backend}")
             try:
                 runner = KernelBenchRunner(
-                    spec_type=spec_type, device=device, backend=backend
+                    spec_type=spec_type,
+                    device=device,
+                    backend=backend,
+                    dtype=dtype,
                 )
 
                 spec_path = runner.specs / level / f"{kernel_name}.yaml"

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -28,6 +28,7 @@ class KernelBenchRunner(KernelRunner):
         csv_path: Path to CSV file for logging (optional)
         note: Optional note to include in CSV
         validate_only: Force a single validation run instead of benchmarking
+        dtype: Run only variants whose problem-spec dtype matches this value
     """
 
     def __init__(
@@ -40,6 +41,7 @@ class KernelBenchRunner(KernelRunner):
         csv_path: str | None = None,
         note: str = "",
         validate_only: bool = False,
+        dtype: str | None = None,
     ):
         super().__init__(
             spec_type=spec_type,
@@ -48,6 +50,7 @@ class KernelBenchRunner(KernelRunner):
             flops_unit=flops_unit,
             mem_bw_unit=mem_bw_unit,
             validate_only=validate_only,
+            dtype=dtype,
         )
         self.specs = ai_utils.specs() / "KernelBench"
         self.csv_path = csv_path
@@ -220,7 +223,7 @@ class KernelBenchRunner(KernelRunner):
             f"Kernel: {spec_path.parent.name} / {spec_path.name} [{self.backend}]"
         )
 
-        variants = ai_hc.expand_variants(spec[self.spec_type])
+        variants = self.get_spec_variants(spec)
         stats = []
         for variant in variants:
             dims = variant.get("dims", {})

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -60,6 +60,7 @@ class KernelRunner:
         csv_path: Path to CSV file for logging (optional)
         note: Optional note to include in CSV
         validate_only: Force a single validation run instead of benchmarking
+        dtype: Run only variants whose problem-spec dtype matches this value
     """
 
     def __init__(
@@ -70,12 +71,14 @@ class KernelRunner:
         flops_unit: config.FlopsUnit = config.FlopsUnit.TFLOPS,
         mem_bw_unit: config.MemBwUnit = config.MemBwUnit.GBS,
         validate_only: bool = False,
+        dtype: str | None = None,
     ):
         self.backend = backend
         self.logger = setup_logger()
         self.flops_unit = flops_unit
         self.mem_bw_unit = mem_bw_unit
         self.validate_only = validate_only
+        self.dtype = dtype
 
         self.spec_type = spec_type
         self.device = device if device else torch.device("cpu")
@@ -208,7 +211,14 @@ class KernelRunner:
         Returns:
             Defined spec type variants
         """
-        return ai_hc.expand_variants(spec[self.spec_type])
+        variants = ai_hc.expand_variants(spec[self.spec_type])
+        if self.dtype is None:
+            return variants
+        return [
+            variant
+            for variant in variants
+            if variant.get(ai_hc.VKey.TYPE) == self.dtype
+        ]
 
     def get_spec_inputs(self, spec: dict) -> dict:
         """Get problem inputs.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -173,6 +173,46 @@ class TestSpecFunctions:
 class TestKernelBenchRunnerInit:
     """Tests for KernelBenchRunner initialization."""
 
+    @mock.patch("os.path.isdir", return_value=True)
+    def test_dtype_filters_expanded_variants(self, mock_isdir):
+        """Test dtype filtering happens after dimension expansion."""
+        spec = {
+            ai_hc.SpecKey.V_CI: [
+                {
+                    ai_hc.VKey.TYPE: "float32",
+                    ai_hc.VKey.DIMS: [{"N": 8}, {"N": 16}],
+                },
+                {
+                    ai_hc.VKey.TYPE: "int64",
+                    ai_hc.VKey.DIMS: {"N": 32},
+                },
+            ]
+        }
+        kb_runner = runner.KernelBenchRunner(dtype="float32")
+
+        variants = kb_runner.get_spec_variants(spec)
+
+        assert [variant[ai_hc.VKey.DIMS]["N"] for variant in variants] == [8, 16]
+        assert all(variant[ai_hc.VKey.TYPE] == "float32" for variant in variants)
+
+    @mock.patch("os.path.isdir", return_value=True)
+    def test_dtype_filter_defaults_to_all_variants(self, mock_isdir):
+        """Test omitting dtype preserves variants of every dtype."""
+        spec = {
+            ai_hc.SpecKey.V_CI: [
+                {ai_hc.VKey.TYPE: "float32", ai_hc.VKey.DIMS: {"N": 8}},
+                {ai_hc.VKey.TYPE: "int64", ai_hc.VKey.DIMS: {"N": 16}},
+            ]
+        }
+        kb_runner = runner.KernelBenchRunner()
+
+        variants = kb_runner.get_spec_variants(spec)
+
+        assert [variant[ai_hc.VKey.TYPE] for variant in variants] == [
+            "float32",
+            "int64",
+        ]
+
     @mock.patch("os.path.isdir")
     def test_init_pytorch_backend(self, mock_isdir):
         """Test runner initialization with PyTorch backend."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,7 @@ class TestCreateParser:
         assert args.note == ""
         assert args.variant is None
         assert args.ci is False
+        assert args.dtype is None
 
     def test_device_group_mutually_exclusive(self):
         """Test that --xpu and --cuda cannot be combined."""
@@ -258,6 +259,38 @@ class TestMainValidateOnly:
 
         assert rc == 0
         assert mock_kernel_runner.call_args.kwargs["validate_only"] is True
+
+
+class TestMainDtype:
+    """Tests for the --dtype variant filter."""
+
+    def test_dtype_forwards_to_kernelbench_runner(self, mock_kb_runner):
+        """Test dtype is forwarded for full KernelBench runs."""
+        rc = cli.main(["--no-env", "--dtype", "float32"])
+
+        assert rc == 0
+        assert mock_kb_runner.call_args.kwargs["dtype"] == "float32"
+
+    def test_dtype_forwards_to_single_kernel_runner(self, mock_kernel_runner, tmp_path):
+        """Test dtype is forwarded in single-kernel mode."""
+        kernel = tmp_path / "double.py"
+        kernel.write_text(_KERNEL_DOUBLE)
+        spec = tmp_path / "double.yaml"
+        spec.write_text(_SPEC_CI)
+
+        rc = cli.main(
+            [
+                "--no-env",
+                "--dtype",
+                "int64",
+                "--kernel",
+                str(kernel),
+                str(spec),
+            ]
+        )
+
+        assert rc == 0
+        assert mock_kernel_runner.call_args.kwargs["dtype"] == "int64"
 
 
 class TestMainUnits:

--- a/tests/test_cli_compare.py
+++ b/tests/test_cli_compare.py
@@ -217,6 +217,17 @@ class TestMainTolerances:
         assert kwargs["atol"] == 1e-6
 
 
+class TestMainDtype:
+    """Tests for the --dtype variant filter."""
+
+    def test_dtype_forwards_to_benchmark(self, mock_backend):
+        """Test dtype is forwarded to comparison benchmarking."""
+        rc = cli_compare.main(["--problem", "level1/double", "--dtype", "bfloat16"])
+
+        assert rc == 0
+        assert mock_backend.benchmark.call_args.kwargs["dtype"] == "bfloat16"
+
+
 class TestMainProblem:
     """Tests for problem argument handling in main()."""
 


### PR DESCRIPTION
Adds a new 'dtype' option to runner and both CLI tools that allows running variants with specified data type only.