### PR TITLE
[CLI] ai-bench-compare output options

### DIFF
--- a/ai_bench/cli_compare.py
+++ b/ai_bench/cli_compare.py
@@ -12,6 +12,7 @@ import argcomplete
 import torch
 
 from ai_bench.harness import core as ai_hc
+from ai_bench.harness import runner as ai_hr
 from ai_bench.harness.runner.benchmark_compare import benchmark_problem
 from ai_bench.harness.runner.benchmark_compare import print_comparison
 from ai_bench.harness.runner.benchmark_compare import print_comparison_brief
@@ -119,6 +120,20 @@ Examples:
         help="Run only variants with this problem-spec dtype (e.g. float32, int64).",
     )
 
+    output_group = parser.add_argument_group("output options")
+    output_group.add_argument(
+        "--gflops",
+        action="store_true",
+        default=False,
+        help="Report GFLOPS (default: TFLOPS)",
+    )
+    output_group.add_argument(
+        "--mbs",
+        action="store_true",
+        default=False,
+        help="Report MB/s (default: GB/s)",
+    )
+
     argcomplete.autocomplete(parser)
     return parser
 
@@ -160,6 +175,9 @@ def main(argv: list[str] | None = None) -> int:
             else ai_hc.SpecKey.V_BENCH_CPU
         )
 
+    flops_unit = ai_hr.FlopsUnit.GFLOPS if args.gflops else ai_hr.FlopsUnit.TFLOPS
+    mem_bw_unit = ai_hr.MemBwUnit.MBS if args.mbs else ai_hr.MemBwUnit.GBS
+
     try:
         results = benchmark_problem(
             problem=args.problem,
@@ -169,6 +187,8 @@ def main(argv: list[str] | None = None) -> int:
             atol=args.atol,
             backends=backends,
             dtype=args.dtype,
+            flops_unit=flops_unit,
+            mem_bw_unit=mem_bw_unit,
         )
         (print_comparison_brief if args.brief else print_comparison)(results)
         return 0

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -10,6 +10,8 @@ import torch
 
 from ai_bench.harness import core as ai_hc
 from ai_bench.harness.runner import KernelBenchRunner
+from ai_bench.harness.runner.config import FlopsUnit
+from ai_bench.harness.runner.config import MemBwUnit
 from ai_bench.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -212,6 +214,8 @@ def benchmark_problem(
     atol: float | None = None,
     backends: Optional[List[ai_hc.Backend]] = None,
     dtype: str | None = None,
+    flops_unit: FlopsUnit = FlopsUnit.TFLOPS,
+    mem_bw_unit: MemBwUnit = MemBwUnit.GBS,
 ) -> dict:
     """Benchmark a specific problem across multiple backends.
 
@@ -228,6 +232,8 @@ def benchmark_problem(
         atol: Override absolute tolerance. If None, uses per-variant spec value.
         backends: List of backends to benchmark
         dtype: Run only variants whose problem-spec dtype matches this value.
+        flops_unit: FLOPS unit to use for reporting.
+        mem_bw_unit: Memory bandwidth unit to use for reporting.
     Returns:
         Dictionary with benchmark results
     """
@@ -274,6 +280,8 @@ def benchmark_problem(
                     device=device,
                     backend=backend,
                     dtype=dtype,
+                    flops_unit=flops_unit,
+                    mem_bw_unit=mem_bw_unit,
                 )
 
                 spec_path = runner.specs / level / f"{kernel_name}.yaml"
@@ -471,12 +479,18 @@ def print_variant_results(variant_result: VariantResult, idx: int = 0):
         r.flops_unit for r in variant_result.backends.values() if r is not None
     ]
     flops_unit = next((f for f in flops_unit_list if f is not None), None)
+    mem_bw_unit_list = [
+        r.mem_bw_unit for r in variant_result.backends.values() if r is not None
+    ]
+    mem_bw_unit = next((m for m in mem_bw_unit_list if m is not None), None)
 
     if not flops_unit:
         flops_unit = "FLOPS"
+    if not mem_bw_unit:
+        mem_bw_unit = "B/s"
     if have_bw:
         logger.info(
-            f"{'Backend':<18} {'Time (μs)':>12} {flops_unit:>8} {'GB/s':>8} {'Speedup':>10}"
+            f"{'Backend':<18} {'Time (μs)':>12} {flops_unit:>8} {mem_bw_unit:>8} {'Speedup':>10}"
         )
         logger.info("-" * 80)
     else:

--- a/tests/test_cli_compare.py
+++ b/tests/test_cli_compare.py
@@ -14,6 +14,8 @@ import torch
 
 from ai_bench import cli_compare
 from ai_bench.harness import core as ai_hc
+from ai_bench.harness import runner as ai_hr
+from ai_bench.harness.runner import benchmark_compare
 from ai_bench.utils import finder
 
 # Minimal, trivial kernel/spec content reused by the integration test. The
@@ -264,6 +266,48 @@ class TestMainOutputFormat:
 
         mock_backend.brief.assert_called_once()
         mock_backend.full.assert_not_called()
+
+
+class TestMainUnits:
+    """Tests for FLOPS and memory-bandwidth unit selection."""
+
+    def test_default_units(self, mock_backend):
+        """Test default units are TFLOPS and GB/s."""
+        cli_compare.main(["--problem", "level1/double"])
+
+        kwargs = mock_backend.benchmark.call_args.kwargs
+        assert kwargs["flops_unit"] == ai_hr.FlopsUnit.TFLOPS
+        assert kwargs["mem_bw_unit"] == ai_hr.MemBwUnit.GBS
+
+    def test_gflops_and_mbs(self, mock_backend):
+        """Test output flags select GFLOPS and MB/s."""
+        cli_compare.main(["--problem", "level1/double", "--gflops", "--mbs"])
+
+        kwargs = mock_backend.benchmark.call_args.kwargs
+        assert kwargs["flops_unit"] == ai_hr.FlopsUnit.GFLOPS
+        assert kwargs["mem_bw_unit"] == ai_hr.MemBwUnit.MBS
+
+    def test_full_output_uses_result_units(self, monkeypatch):
+        """Test full output labels performance columns with result units."""
+        result = types.SimpleNamespace(
+            meas_us=1.0,
+            flops=2.0,
+            flops_unit=ai_hr.FlopsUnit.GFLOPS,
+            mem_bw=3.0,
+            mem_bw_unit=ai_hr.MemBwUnit.MBS,
+        )
+        variant = benchmark_compare.VariantResult(
+            backends={"pytorch": result},
+            speedups={"pytorch": 1.0},
+        )
+        info = mock.MagicMock()
+        monkeypatch.setattr(benchmark_compare.logger, "info", info)
+
+        benchmark_compare.print_variant_results(variant)
+
+        output = "\n".join(str(call.args[0]) for call in info.call_args_list)
+        assert "GFLOPS" in output
+        assert "MB/s" in output
 
 
 class TestMainErrorHandling:


### PR DESCRIPTION
Adds '--gflops' and '--mbs' output options to 'ai-bench-compare' to allow control over tool's output units and to align the two CLI tools.