### PR TITLE
[harness] Log variant dtype in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The CSV file includes the following columns:
 - `mem_note`: Memory measurement annotation (see 'Notes legend')
 - `time_us`: Execution time in microseconds
 - `input_values`: Input dimensions as JSON
+- `dtype`: Variant's data type if specified
 - `note`: User-provided note
 
 Additionally, any environment variables prefixed with `AIBENCH_` are automatically captured and included in the CSV output. This is useful for recording system configuration:

--- a/ai_bench/harness/runner/kernel_bench_runner.py
+++ b/ai_bench/harness/runner/kernel_bench_runner.py
@@ -69,6 +69,7 @@ class KernelBenchRunner(KernelRunner):
             "mem_note",
             "time_us",
             "input_values",
+            "dtype",
             "note",
         ]
         aibench_env_keys = sorted(
@@ -172,6 +173,7 @@ class KernelBenchRunner(KernelRunner):
                             "input_values": json.dumps(
                                 run.variant.get(ai_hc.VKey.DIMS, {})
                             ),
+                            "dtype": run.variant.get(ai_hc.VKey.TYPE, ""),
                             "note": self.note,
                         }
                         row.update(aibench_env)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -42,9 +42,10 @@ def test_csv_logging_and_env_capture(monkeypatch, temp_csv_file):
 inputs:
   X:
     shape: [N]
-    dtype: float32
+    dtype: inherit
 bench-cpu:
   - params: [X]
+    dtype: float32
     dims:
       N: 4
     flop: 8*N
@@ -90,6 +91,7 @@ class Model(torch.nn.Module):
     row = rows[0]
     assert row.get("flops_unit") == "TFLOPS"
     assert row.get("mem_bw_unit") == "GB/s"
+    assert row.get("dtype") == "float32"
     assert row.get("note") == "Unit test note"
     assert row.get("AIBENCH_CARD") == "D770"
     assert row.get("AIBENCH_SYSTEM") == "TestSystem"


### PR DESCRIPTION
Adds new 'dtype' entry to logged CSV file to track variant's dtype value.