### PR TITLE
[harness][mlir] MLIR XPU backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ A benchmarking framework for evaluating AI kernel implementations across multipl
 | | PyTorch | Triton | Helion | MLIR | Gluon | SYCL |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **CPU** | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
-| **XPU** | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| **XPU** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **CUDA** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 ✅ - Supported ⚠️ - Partially implemented ❌ - Unsupported
+
+_NOTE_: MLIR XPU requires **custom** LLVM build with Intel GPU support enabled.  
+Override `PYTHONPATH` to point to `mlir_core` packages and ensure LLVM libs can be found.
 
 ## Project Docs
 * [**Problem Specification Files**](docs/problem_spec.md)

--- a/ai_bench/harness/runner/benchmark_compare.py
+++ b/ai_bench/harness/runner/benchmark_compare.py
@@ -314,17 +314,28 @@ def benchmark_problem(
                 if backend == ai_hc.Backend.MLIR:
                     import ai_bench.mlir as ai_mlir
 
+                    if runner.device.type == "cuda":
+                        raise ValueError("MLIR CUDA backend is not supported")
+
                     mlir_pipeline = None
                     if hasattr(model, "mlir_pipeline"):
                         mlir_pipeline = model.mlir_pipeline
                     model_dtype = ai_hc.get_variant_dtype(variants[variant_idx])
+                    if runner.device.type == "xpu":
+                        compile_fn = ai_mlir.get_xpu_compile_fn(
+                            pipeline=mlir_pipeline, dtype=model_dtype
+                        )
+                        mlir_backend = ai_mlir.gpu_backend(
+                            compile_fn, device=runner.device
+                        )
+                    else:
+                        compile_fn = ai_mlir.get_cpu_compile_fn(
+                            pipeline=mlir_pipeline, dtype=model_dtype
+                        )
+                        mlir_backend = ai_mlir.cpu_backend(compile_fn)
                     model.compile(
                         dynamic=False,
-                        backend=ai_mlir.cpu_backend(
-                            ai_mlir.get_cpu_compile_fn(
-                                pipeline=mlir_pipeline, dtype=model_dtype
-                            )
-                        ),
+                        backend=mlir_backend,
                     )
                 # save pytorch model for correctness check
                 if backend == str(ai_hc.Backend.PYTORCH):

--- a/ai_bench/harness/runner/kernel_runner.py
+++ b/ai_bench/harness/runner/kernel_runner.py
@@ -401,17 +401,26 @@ class KernelRunner:
             if self.backend == ai_hc.Backend.MLIR:
                 import ai_bench.mlir as ai_mlir
 
+                if self.is_cuda():
+                    raise ValueError("MLIR CUDA backend is not supported")
+
                 mlir_pipeline = None
                 if hasattr(model, "mlir_pipeline"):
                     mlir_pipeline = model.mlir_pipeline
                 model_dtype = ai_hc.get_variant_dtype(variant)
+                if self.is_xpu():
+                    compile_fn = ai_mlir.get_xpu_compile_fn(
+                        pipeline=mlir_pipeline, dtype=model_dtype
+                    )
+                    backend = ai_mlir.gpu_backend(compile_fn, device=self.device)
+                else:
+                    compile_fn = ai_mlir.get_cpu_compile_fn(
+                        pipeline=mlir_pipeline, dtype=model_dtype
+                    )
+                    backend = ai_mlir.cpu_backend(compile_fn)
                 model.compile(
                     dynamic=False,
-                    backend=ai_mlir.cpu_backend(
-                        ai_mlir.get_cpu_compile_fn(
-                            pipeline=mlir_pipeline, dtype=model_dtype
-                        )
-                    ),
+                    backend=backend,
                 )
 
             args = ai_hc.get_inputs(variant, spec_inputs, device=self.device)

--- a/ai_bench/mlir/__init__.py
+++ b/ai_bench/mlir/__init__.py
@@ -1,9 +1,15 @@
 from .compile import cpu_backend
+from .compile import gpu_backend
 from .pipeline import cpu_pipeline
 from .pipeline import get_cpu_compile_fn
+from .pipeline import get_xpu_compile_fn
+from .pipeline import xpu_pipeline
 
 __all__ = [
     "cpu_backend",
     "cpu_pipeline",
     "get_cpu_compile_fn",
+    "get_xpu_compile_fn",
+    "gpu_backend",
+    "xpu_pipeline",
 ]

--- a/ai_bench/mlir/compile.py
+++ b/ai_bench/mlir/compile.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from collections.abc import Sequence
 import os
+from pathlib import Path
 import warnings
 
 import lighthouse.ingress.torch.compile as lh_compile
@@ -8,6 +9,28 @@ from mlir import ir
 import torch
 
 from ai_bench.utils.logger import setup_logger
+
+
+def _xpu_matmul_params_file() -> str:
+    """Return the local XeGPU matmul parameter database path."""
+    return str(
+        Path(__file__).resolve().parents[2]
+        / "backends"
+        / "utils"
+        / "mlir_xpu_utils"
+        / "matmul_params.json"
+    )
+
+
+def _override_lighthouse_xpu_param_db(logger) -> None:
+    """Point Lighthouse XeGPU parameter selector to AI-bench's local JSON DB."""
+    from lighthouse.schedule.xegpu import xegpu_parameter_selector
+
+    json_file = _xpu_matmul_params_file()
+    if not Path(json_file).exists():
+        raise FileNotFoundError(f"Missing XPU matmul params file: {json_file}")
+    xegpu_parameter_selector.DEFAULT_JSON_FILE = json_file
+    logger.info(f"--- MLIR XPU - Using matmul params: {json_file}")
 
 
 class CPUBackend(lh_compile.MLIRBackend):
@@ -100,6 +123,39 @@ class CPUBackend(lh_compile.MLIRBackend):
         return jit_func
 
 
+class GPUBackend(CPUBackend):
+    """
+    A wrapper around PyTorch MLIR GPU backend.
+
+    Reuses the AI-bench MLIR wrapper behavior while targeting an accelerator
+    device supported by Lighthouse's GPU backend.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        fn_compile: Callable[[ir.Module], ir.Module],
+        dialect: lh_compile.TargetDialect = lh_compile.TargetDialect.LINALG_ON_TENSORS,
+        ir_context: ir.Context | None = None,
+        shared_libs: Sequence[str] = [],
+        **kwargs,
+    ):
+        assert device.type in ("cuda", "rocm", "xpu"), "Expected a GPU device"
+        logger = setup_logger()
+        if device.type == "xpu":
+            _override_lighthouse_xpu_param_db(logger)
+            shared_libs = list(shared_libs)
+            shared_libs.append("libmlir_levelzero_runtime.so")
+        super().__init__(
+            device,
+            fn_compile,
+            dialect=dialect,
+            ir_context=ir_context,
+            shared_libs=shared_libs,
+            **kwargs,
+        )
+
+
 def cpu_backend(
     fn_compile: Callable[[ir.Module], ir.Module],
     dialect: lh_compile.TargetDialect = lh_compile.TargetDialect.LINALG_ON_TENSORS,
@@ -124,6 +180,40 @@ def cpu_backend(
     """
     return CPUBackend(
         torch.device("cpu"),
+        fn_compile,
+        dialect=dialect,
+        ir_context=ir_context,
+        shared_libs=shared_libs,
+        **kwargs,
+    )
+
+
+def gpu_backend(
+    fn_compile: Callable[[ir.Module], ir.Module],
+    device: torch.device,
+    dialect: lh_compile.TargetDialect = lh_compile.TargetDialect.LINALG_ON_TENSORS,
+    ir_context: ir.Context | None = None,
+    shared_libs: Sequence[str] = [],
+    **kwargs,
+) -> Callable[[torch.fx.GraphModule, list[torch.Tensor]], Callable]:
+    """
+    GPU backend for JIT-compiling a PyTorch model using MLIR.
+
+    Args:
+        fn_compile: Function to compile imported MLIR to LLVM IR dialect.
+            The function accepts an MLIR module, and returns an MLIR module with
+            transformed IR.
+        device: Target GPU device.
+        dialect: The target dialect for MLIR IR imported from PyTorch model.
+        ir_context: An optional MLIR context to use for compilation.
+        shared_libs: Paths to external runtime libraries used to execute
+            compiled MLIR function.
+
+    Returns:
+        object: A PyTorch model or a partially bound decorator.
+    """
+    return GPUBackend(
+        device,
         fn_compile,
         dialect=dialect,
         ir_context=ir_context,

--- a/ai_bench/mlir/compile.py
+++ b/ai_bench/mlir/compile.py
@@ -11,6 +11,7 @@ import torch
 from ai_bench.utils.logger import setup_logger
 
 
+# TODO: Add proper discovery to 'finder' module if params need to be kept locally.
 def _xpu_matmul_params_file() -> str:
     """Return the local XeGPU matmul parameter database path."""
     return str(
@@ -22,6 +23,7 @@ def _xpu_matmul_params_file() -> str:
     )
 
 
+# TODO: Fix configuration in Lighthouse.
 def _override_lighthouse_xpu_param_db(logger) -> None:
     """Point Lighthouse XeGPU parameter selector to AI-bench's local JSON DB."""
     from lighthouse.schedule.xegpu import xegpu_parameter_selector

--- a/ai_bench/mlir/pipeline.py
+++ b/ai_bench/mlir/pipeline.py
@@ -60,13 +60,15 @@ def _get_logger():
 
 
 @cache
-def _get_target_info() -> TargetInfo:
+def _get_target_info(device_type: str = "cpu") -> TargetInfo:
     """
-    Get target information for the current CPU architecture.
+    Get target information for the active compilation target.
 
     Returns:
         TargetInfo object containing architecture and feature information.
     """
+    if device_type == "xpu":
+        return TargetInfo(arch="xegpu", features=[])
     return TargetInfo()
 
 
@@ -74,6 +76,7 @@ def _select_pipeline_file(
     pipeline: str | None = None,
     dtype: str | None = None,
     base_path: Path | None = None,
+    device_type: str = "cpu",
 ) -> str:
     """
     Dynamically select a lowering pipeline descriptor (YAML).
@@ -95,7 +98,7 @@ def _select_pipeline_file(
 
     if pipeline:
         file, _ = find_pipeline_file(
-            target=_get_target_info(),
+            target=_get_target_info(device_type),
             pipeline=pipeline,
             dtype=normalize_dtype(dtype),
             base_path=base_path,
@@ -106,8 +109,11 @@ def _select_pipeline_file(
     return pipeline_file
 
 
-def cpu_pipeline(
-    module: ir.Module, pipeline: str | None = None, dtype: str | None = None
+def _compile_pipeline(
+    module: ir.Module,
+    pipeline: str | None = None,
+    dtype: str | None = None,
+    device_type: str = "cpu",
 ) -> ir.Module:
     """
     The default lowering pipeline for CPU.
@@ -127,7 +133,10 @@ def cpu_pipeline(
     """
     base_path = mlir_schedules_dir()
     pipeline_file = _select_pipeline_file(
-        pipeline=pipeline, dtype=dtype, base_path=base_path
+        pipeline=pipeline,
+        dtype=dtype,
+        base_path=base_path,
+        device_type=device_type,
     )
     _get_logger().info(f"  MLIR pipeline: {pipeline_file}")
 
@@ -141,7 +150,27 @@ def cpu_pipeline(
     return module
 
 
+def cpu_pipeline(
+    module: ir.Module, pipeline: str | None = None, dtype: str | None = None
+) -> ir.Module:
+    """Lower MLIR for a CPU target."""
+    return _compile_pipeline(module, pipeline=pipeline, dtype=dtype, device_type="cpu")
+
+
+def xpu_pipeline(
+    module: ir.Module, pipeline: str | None = None, dtype: str | None = None
+) -> ir.Module:
+    """Lower MLIR for an XPU target."""
+    return _compile_pipeline(module, pipeline=pipeline, dtype=dtype, device_type="xpu")
+
+
 def get_cpu_compile_fn(
     pipeline: str | None = None, dtype: str | None = None
 ) -> Callable[[ir.Module], ir.Module]:
     return functools.partial(cpu_pipeline, pipeline=pipeline, dtype=dtype)
+
+
+def get_xpu_compile_fn(
+    pipeline: str | None = None, dtype: str | None = None
+) -> Callable[[ir.Module], ir.Module]:
+    return functools.partial(xpu_pipeline, pipeline=pipeline, dtype=dtype)

--- a/backends/mlir/xpu/KernelBench/level1/1_Square_matrix_multiplication_.py
+++ b/backends/mlir/xpu/KernelBench/level1/1_Square_matrix_multiplication_.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    """
+    Simple model that performs a single square matrix multiplication (C = A * B)
+    """
+
+    mlir_pipeline = "matmul"
+
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
+        assert all(dim == 4096 for dim in A.shape), "A shape must be 4096"
+        assert all(dim == 4096 for dim in B.shape), "B shape must be 4096"
+
+        return torch.matmul(A, B)

--- a/backends/utils/mlir_xpu_utils/matmul_params.json
+++ b/backends/utils/mlir_xpu_utils/matmul_params.json
@@ -1,0 +1,24 @@
+[
+    {
+      "m" : 4096,
+      "n" : 4096,
+      "k" : 4096,
+      "wg_m" : 256,
+      "wg_n" : 256,
+      "sg_m" : 32,
+      "sg_n" : 64,
+      "k_tile" : 32,
+      "load_a_m" : 32,
+      "load_a_k" : 32,
+      "load_b_k" : 16,
+      "load_b_n" : 32,
+      "prefetch_a_m" : 16,
+      "prefetch_a_k" : 16,
+      "prefetch_b_k" : 16,
+      "prefetch_b_n" : 16,
+      "prefetch_a_nb" : 1,
+      "prefetch_b_nb" : 2,
+      "transpose_a" : false,
+      "transpose_b" : false
+    }
+]

--- a/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
+++ b/problems/specs/KernelBench/level1/1_Square_matrix_multiplication_.yaml
@@ -42,6 +42,14 @@ mlir-cpu-bench:
     atol: 1
     flop: "2*N*N*N"
 
+mlir-gpu-bench:
+  - params: [A, B]
+    dtype: bfloat16
+    dims:
+      N: 4096
+    atol: 1
+    flop: "2*N*N*N"
+
 bench-gpu:
   - params: [A, B]
     dtype: float16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ dev = [
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
+timeout = 60
 filterwarnings = [
     'error', # Turn all uncaptured warnings into errors.
     'ignore::DeprecationWarning',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -473,6 +473,9 @@ class TestKernelBenchRunnerExecution:
             mlir_xpu_kernels_dir = (
                 tmpdir / "backends" / "mlir" / "xpu" / "KernelBench" / "level1"
             )
+            mlir_cuda_kernels_dir = (
+                tmpdir / "backends" / "mlir" / "cuda" / "KernelBench" / "level1"
+            )
 
             specs_dir.mkdir(parents=True)
             pytorch_kernels_dir.mkdir(parents=True)
@@ -480,6 +483,7 @@ class TestKernelBenchRunnerExecution:
             helion_kernels_dir.mkdir(parents=True)
             mlir_cpu_kernels_dir.mkdir(parents=True)
             mlir_xpu_kernels_dir.mkdir(parents=True)
+            mlir_cuda_kernels_dir.mkdir(parents=True)
 
             yield {
                 "root": tmpdir,
@@ -489,6 +493,7 @@ class TestKernelBenchRunnerExecution:
                 "helion_kernels": helion_kernels_dir,
                 "mlir_cpu_kernels": mlir_cpu_kernels_dir,
                 "mlir_xpu_kernels": mlir_xpu_kernels_dir,
+                "mlir_cuda_kernels": mlir_cuda_kernels_dir,
             }
 
     def _create_spec_file(self, specs_dir: Path, filename: str, content: str):
@@ -860,6 +865,162 @@ class Model(torch.nn.Module):
             assert "mlir/cpu" in str(mlir_cpu_runner.kernels)
             assert "mlir/xpu" in str(mlir_xpu_runner.kernels)
 
+    def test_run_kernel_spec_mlir_cpu_uses_cpu_backend(self, temp_dirs):
+        """Test MLIR CPU execution uses the CPU backend wrapper."""
+        spec_content = """
+inputs:
+  X:
+    shape: [N]
+    dtype: bfloat16
+ci:
+  - params: [X]
+    dims:
+      N: 8
+    dtype: bfloat16
+"""
+        kernel_content = """
+import torch
+
+class Model(torch.nn.Module):
+    mlir_pipeline = "matmul"
+
+    def forward(self, x):
+        return x
+"""
+        self._create_spec_file(temp_dirs["specs"], "mlir_cpu.yaml", spec_content)
+        self._create_kernel_file(
+            temp_dirs["mlir_cpu_kernels"], "mlir_cpu.py", kernel_content
+        )
+
+        fake_mlir = mock.MagicMock()
+        fake_mlir.get_cpu_compile_fn.return_value = "cpu-compile-fn"
+        fake_mlir.cpu_backend.return_value = "cpu-backend"
+
+        class FakeModel:
+            mlir_pipeline = "matmul"
+
+            def __init__(self):
+                self.compile = mock.Mock()
+
+            def __call__(self, *args):
+                return args
+
+        with (
+            mock.patch(
+                "ai_bench.utils.finder.project_root", return_value=temp_dirs["root"]
+            ),
+            mock.patch.dict("sys.modules", {"ai_bench.mlir": fake_mlir}),
+            mock.patch(
+                "ai_bench.harness.core.get_inputs", return_value=[torch.tensor([1])]
+            ),
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("cpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
+            fake_model = FakeModel()
+            with mock.patch.object(kb_runner, "init_model", return_value=fake_model):
+                kb_runner.run_kernel_spec(
+                    temp_dirs["mlir_cpu_kernels"] / "mlir_cpu.py",
+                    temp_dirs["specs"] / "mlir_cpu.yaml",
+                )
+
+        fake_mlir.get_cpu_compile_fn.assert_called_once_with(
+            pipeline="matmul", dtype="bfloat16"
+        )
+        fake_mlir.cpu_backend.assert_called_once_with("cpu-compile-fn")
+        fake_mlir.get_xpu_compile_fn.assert_not_called()
+        fake_mlir.gpu_backend.assert_not_called()
+        fake_model.compile.assert_called_once_with(dynamic=False, backend="cpu-backend")
+
+    def test_run_kernel_spec_mlir_xpu_uses_gpu_backend(self, temp_dirs):
+        """Test MLIR XPU execution uses the GPU backend wrapper."""
+        spec_content = """
+inputs:
+  X:
+    shape: [N]
+    dtype: bfloat16
+ci:
+  - params: [X]
+    dims:
+      N: 8
+    dtype: bfloat16
+"""
+        kernel_content = """
+import torch
+
+class Model(torch.nn.Module):
+    mlir_pipeline = "matmul"
+
+    def forward(self, x):
+        return x
+"""
+        self._create_spec_file(temp_dirs["specs"], "mlir_xpu.yaml", spec_content)
+        self._create_kernel_file(
+            temp_dirs["mlir_xpu_kernels"], "mlir_xpu.py", kernel_content
+        )
+
+        fake_mlir = mock.MagicMock()
+        fake_mlir.get_cpu_compile_fn.return_value = "cpu-compile-fn"
+        fake_mlir.cpu_backend.return_value = "cpu-backend"
+        fake_mlir.get_xpu_compile_fn.return_value = "xpu-compile-fn"
+        fake_mlir.gpu_backend.return_value = "xpu-backend"
+
+        class FakeModel:
+            mlir_pipeline = "matmul"
+
+            def __init__(self):
+                self.compile = mock.Mock()
+
+            def __call__(self, *args):
+                return args
+
+        with (
+            mock.patch(
+                "ai_bench.utils.finder.project_root", return_value=temp_dirs["root"]
+            ),
+            mock.patch.dict("sys.modules", {"ai_bench.mlir": fake_mlir}),
+            mock.patch(
+                "ai_bench.harness.core.get_inputs", return_value=[torch.tensor([1])]
+            ),
+        ):
+            kb_runner = runner.KernelBenchRunner(
+                spec_type=ai_hc.SpecKey.V_CI,
+                device=torch.device("xpu"),
+                backend=ai_hc.Backend.MLIR,
+            )
+            fake_model = FakeModel()
+            with mock.patch.object(kb_runner, "init_model", return_value=fake_model):
+                kb_runner.run_kernel_spec(
+                    temp_dirs["mlir_xpu_kernels"] / "mlir_xpu.py",
+                    temp_dirs["specs"] / "mlir_xpu.yaml",
+                )
+
+        fake_mlir.get_cpu_compile_fn.assert_not_called()
+        fake_mlir.cpu_backend.assert_not_called()
+        fake_mlir.get_xpu_compile_fn.assert_called_once_with(
+            pipeline="matmul", dtype="bfloat16"
+        )
+        fake_mlir.gpu_backend.assert_called_once_with(
+            "xpu-compile-fn", device=torch.device("xpu")
+        )
+        fake_model.compile.assert_called_once_with(dynamic=False, backend="xpu-backend")
+
+    def test_xpu_pipeline_lookup_uses_xegpu_descriptors(self):
+        """Test XPU compile helper resolves the packaged xegpu matmul pipeline."""
+        pytest.importorskip("lighthouse")
+        from ai_bench.mlir import pipeline as ai_mlir_pipeline
+
+        pipeline_file = ai_mlir_pipeline._select_pipeline_file(
+            pipeline="matmul",
+            dtype="bfloat16",
+            base_path=Path("tmp/nonexistent-mlir-schedules"),
+            device_type="xpu",
+        )
+
+        assert pipeline_file.endswith("xegpu/matmul/bf16.yaml")
+
     def test_run_kernels_with_inits(self, temp_dirs):
         """Test running kernel that requires initialization parameters."""
         spec_content = """
@@ -1198,17 +1359,14 @@ class Model(torch.nn.Module):
 
     def test_full_ci_pipeline_mlir(self, integration_setup):
         """Test complete CI pipeline with MLIR backend."""
-        # The real MLIR backend requires the optional 'lighthouse' dependency,
-        # which is not available in the unit-test environment. Stub the
-        # 'ai_bench.mlir' module so the runner compiles the model with torch's
-        # eager backend instead of a full MLIR lowering.
-        fake_mlir = mock.MagicMock()
-        fake_mlir.cpu_backend.return_value = "eager"
+        # Force torch.compile to use eager backend for this integration test.
+        # Patching the module symbol is more robust than swapping sys.modules
+        # because ai_bench.mlir may already be imported by earlier tests.
         with (
             mock.patch(
                 "ai_bench.utils.finder.project_root", return_value=integration_setup
             ),
-            mock.patch.dict("sys.modules", {"ai_bench.mlir": fake_mlir}),
+            mock.patch("ai_bench.mlir.cpu_backend", return_value="eager"),
         ):
             kb_runner = runner.KernelBenchRunner(
                 spec_type=ai_hc.SpecKey.V_CI,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1359,14 +1359,22 @@ class Model(torch.nn.Module):
 
     def test_full_ci_pipeline_mlir(self, integration_setup):
         """Test complete CI pipeline with MLIR backend."""
-        # Force torch.compile to use eager backend for this integration test.
-        # Patching the module symbol is more robust than swapping sys.modules
-        # because ai_bench.mlir may already be imported by earlier tests.
+        import ai_bench
+
+        fake_mlir = mock.MagicMock()
+        fake_mlir.cpu_backend.return_value = "eager"
+        # Two patches are required:
+        # 1. sys.modules["ai_bench.mlir"] — for `import ai_bench.mlir as ai_mlir`
+        #    when the module is NOT yet loaded.
+        # 2. ai_bench.mlir attribute — for the IMPORT_FROM bytecode which does
+        #    getattr(ai_bench, "mlir") instead of a sys.modules lookup when the
+        #    module was already imported by an earlier test.
         with (
             mock.patch(
                 "ai_bench.utils.finder.project_root", return_value=integration_setup
             ),
-            mock.patch("ai_bench.mlir.cpu_backend", return_value="eager"),
+            mock.patch.dict("sys.modules", {"ai_bench.mlir": fake_mlir}),
+            mock.patch.object(ai_bench, "mlir", fake_mlir, create=True),
         ):
             kb_runner = runner.KernelBenchRunner(
                 spec_type=ai_hc.SpecKey.V_CI,


### PR DESCRIPTION
Adds initial support for kernels using MLIR XPU backend. The integration goes through Lighthouse infrastructure for XPU.

Note: XPU-enabled LLVM currently is not provided automatically. A custom LLVM build is required to use MLIR XPU.