### PR TITLE
[TritonCPU] Integrate last-dim reductions and softmax into SFC matmul utility

### DIFF
--- a/backends/triton/cpu/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.py
+++ b/backends/triton/cpu/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.py
@@ -9,8 +9,13 @@ import triton
 import triton.language as tl
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
+
+
+@triton.jit
+def _gemm_epilogue(x):
+    x /= 2.0
+    return x
 
 
 class Model(nn.Module):
@@ -19,15 +24,6 @@ class Model(nn.Module):
         self.weight = nn.Parameter(torch.randn(hidden_size, input_size))
         self.scaling_factor = scaling_factor
 
-        @triton.jit
-        def _gemm_epilogue(x):
-            x /= 2.0
-            return x
-
-        @triton.jit
-        def _red(val, block, **kwargs):
-            return val + tl.sum(block, axis=0)
-
         sf_val = tl.constexpr(scaling_factor)
 
         @triton.jit
@@ -35,8 +31,6 @@ class Model(nn.Module):
             x *= sf_val
             return x
 
-        self._gemm_epilogue_fun = _gemm_epilogue
-        self._red_fun = _red
         self._red_epilogue_fun = _red_epilogue
         self._weight_packed = None
 
@@ -49,22 +43,13 @@ class Model(nn.Module):
                 BLOCK_SIZE_K=32,
             )
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
-            trunc_output=False,
-            post_op=self._gemm_epilogue_fun,
+            post_op=_gemm_epilogue,
+            reduce_last_dim=True,
+            reduction_post_op=self._red_epilogue_fun,
+            keep_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=self._red_fun,
-            post_op=self._red_epilogue_fun,
-            keep_dim=True,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.py
+++ b/backends/triton/cpu/KernelBench/level2/18_Matmul_Sum_Max_AvgPool_LogSumExp_LogSumExp.py
@@ -5,16 +5,9 @@
 
 import torch.nn as nn
 import triton
-import triton.language as tl
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
-
-
-@triton.jit
-def _red(val, block, **kwargs):
-    return val + tl.sum(block, axis=0)
 
 
 class Model(nn.Module):
@@ -34,21 +27,12 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             self._bias,
-            trunc_output=False,
+            reduce_last_dim=True,
+            keep_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=_red,
-            keep_dim=True,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.py
+++ b/backends/triton/cpu/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.py
@@ -9,14 +9,12 @@ import triton.language as tl
 
 from triton_cpu_utils import mish
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _red(val, x, **kwargs):
-    x = tl.exp(x)
-    return val + tl.sum(x, axis=0)
+def _red_block(block, **kwargs):
+    return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
@@ -53,23 +51,15 @@ class Model(nn.Module):
             )
             self._bias = self.matmul.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             self._bias,
             post_op=self._mm_epi_fun,
-            trunc_output=False,
+            reduce_last_dim=True,
+            reduction_block_op=_red_block,
+            reduction_post_op=_red_epi,
+            keep_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=_red,
-            post_op=_red_epi,
-            keep_dim=True,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.py
+++ b/backends/triton/cpu/KernelBench/level2/30_Gemm_GroupNorm_Hardtanh.py
@@ -47,8 +47,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/33_Gemm_Scale_BatchNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/33_Gemm_Scale_BatchNorm.py
@@ -54,8 +54,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
             post_op_arg=self._scale,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.py
@@ -54,10 +54,10 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
             post_op_arg=self._bias_extra,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/39_Gemm_Scale_BatchNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/39_Gemm_Scale_BatchNorm.py
@@ -54,8 +54,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
             post_op_arg=self._scale,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.py
+++ b/backends/triton/cpu/KernelBench/level2/41_Gemm_BatchNorm_GELU_ReLU.py
@@ -47,7 +47,7 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.py
+++ b/backends/triton/cpu/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.py
@@ -8,7 +8,6 @@ import triton
 import triton.language as tl
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
@@ -18,9 +17,8 @@ def _mm1_epi(x):
 
 
 @triton.jit
-def _red(val, x, **kwargs):
-    x = tl.exp(x)
-    return val + tl.sum(x, axis=0)
+def _red_block(block, **kwargs):
+    return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
@@ -65,21 +63,13 @@ class Model(nn.Module):
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
 
-        res_mm2 = sfc_matmul(
+        return sfc_matmul(
             res_mm1,
             self._weight2_packed,
             self._bias2,
-            trunc_output=False,
+            reduce_last_dim=True,
+            reduction_block_op=_red_block,
+            reduction_post_op=_red_epi,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, res_mm1.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm2,
-            out_dtype=x.dtype,
-            reduction=_red,
-            post_op=_red_epi,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.py
+++ b/backends/triton/cpu/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.py
@@ -10,7 +10,6 @@ import triton.language as tl
 
 from triton_cpu_utils import gelu
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
@@ -24,11 +23,6 @@ def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
     )
     neg_bias = desc.load([block_n * BLOCK_SIZE_N]).to(x.dtype)
     return x - neg_bias[None, :]
-
-
-@triton.jit
-def _red(val, x, **kwargs):
-    return val + tl.sum(x, axis=0)
 
 
 @triton.jit
@@ -86,20 +80,15 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
             post_op_arg=self._neg_bias,
+            reduce_last_dim=True,
+            reduction_post_op=_red_epi,
+            keep_dim=True,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
-        )
-
-        res_mean = reduce_last_dim(
-            res_mm,
-            out_dtype=res_mm.dtype,
-            reduction=_red,
-            post_op=_red_epi,
-            keep_dim=True,
         )
 
         # The logsumexp after the first reduction is a no-op, so we fuse the gelu right away.
@@ -108,7 +97,7 @@ class Model(nn.Module):
         BLOCK_SIZE_K = 256
         assert x.shape[1] % BLOCK_SIZE_K == 0, "K must be divisible by BLOCK_SIZE_K"
         _residual_add[(x.shape[0],)](
-            col_vec_ptr=res_mean,
+            col_vec_ptr=res_mm,
             orig_mat_ptr=x,
             out_mat_ptr=res,
             M=x.shape[0],

--- a/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
+++ b/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
@@ -50,9 +50,9 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             reduce_last_dim=True,
             reduction_block_op=self._red_block_fun,
             reduction_post_op=self._red_epi_fun,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
+++ b/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
@@ -8,7 +8,6 @@ import triton
 import triton.language as tl
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
@@ -22,10 +21,10 @@ class Model(nn.Module):
         sf_val = tl.constexpr(scale_factor)
 
         @triton.jit
-        def _red(val, x, BLOCK_SIZE_N, **kwargs):
-            x = x.reshape([BLOCK_SIZE_N // kern_sz, kern_sz])
-            xm = tl.max(x, axis=1)
-            return val + tl.sum(xm, axis=0)
+        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N, **kwargs):
+            block = block.reshape([BLOCK_SIZE_M, BLOCK_SIZE_N // kern_sz, kern_sz])
+            xm = tl.max(block, axis=2)
+            return tl.sum(xm, axis=1)
 
         @triton.jit
         def _red_epi(val, **kwargs):
@@ -34,7 +33,7 @@ class Model(nn.Module):
 
         self._weight_packed = None
         self._bias = None
-        self._red_fun = _red
+        self._red_block_fun = _red_block
         self._red_epi_fun = _red_epi
 
     def forward(self, x):
@@ -47,19 +46,13 @@ class Model(nn.Module):
             )
             self._bias = self.matmul.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             bias=self._bias,
             b_is_prepacked=True,
-            trunc_output=False,
-            c_is_owned=True,
+            reduce_last_dim=True,
+            reduction_block_op=self._red_block_fun,
+            reduction_post_op=self._red_epi_fun,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
-        )
-
-        return reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=self._red_fun,
-            post_op=self._red_epi_fun,
         )

--- a/backends/triton/cpu/KernelBench/level2/56_Matmul_Sigmoid_Sum.py
+++ b/backends/triton/cpu/KernelBench/level2/56_Matmul_Sigmoid_Sum.py
@@ -8,18 +8,12 @@ import triton
 import triton.language as tl
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
 def _mm_epi(x):
     return tl.sigmoid(x)
-
-
-@triton.jit
-def _red(val, x, **kwargs):
-    return val + tl.sum(x, axis=0)
 
 
 class Model(nn.Module):
@@ -39,22 +33,13 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             self._bias,
             post_op=_mm_epi,
-            trunc_output=False,
+            reduce_last_dim=True,
+            keep_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=_red,
-            keep_dim=True,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.py
+++ b/backends/triton/cpu/KernelBench/level2/62_Matmul_GroupNorm_LeakyReLU_Sum.py
@@ -47,9 +47,9 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
+            trunc_output=False,
             b_is_prepacked=True,
             c_is_owned=True,
-            trunc_output=False,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
 

--- a/backends/triton/cpu/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.py
+++ b/backends/triton/cpu/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.py
@@ -9,14 +9,12 @@ import triton.language as tl
 
 from triton_cpu_utils import gelu
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _red(val, x, **kwargs):
-    x = tl.exp(x)
-    return val + tl.sum(x, axis=0)
+def _red_block(block, **kwargs):
+    return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
@@ -47,22 +45,14 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             self._bias,
-            trunc_output=False,
+            reduce_last_dim=True,
+            reduction_block_op=_red_block,
+            reduction_post_op=_red_epi,
+            keep_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        res_red = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=_red,
-            post_op=_red_epi,
-            keep_dim=True,
-        )
-
-        return res_red

--- a/backends/triton/cpu/KernelBench/level2/66_Matmul_Dropout_Softmax.py
+++ b/backends/triton/cpu/KernelBench/level2/66_Matmul_Dropout_Softmax.py
@@ -8,7 +8,6 @@ import triton
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
 from triton_cpu_utils import sfc_matmul
-from triton_cpu_utils import softmax
 
 
 class Model(nn.Module):
@@ -28,16 +27,12 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        # We are running in inference mode, so dropout is not applied.
+        return sfc_matmul(
             x,
             self._weight_packed,
             bias=self._bias,
-            trunc_output=False,
+            softmax_last_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        # We are running in inference mode, so dropout is not applied.
-
-        return softmax(res_mm, out_dtype=x.dtype)

--- a/backends/triton/cpu/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.py
+++ b/backends/triton/cpu/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.py
@@ -15,6 +15,11 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
+def _min_init_val(dtype, **kwargs):
+    return tl.full([], float("inf"), dtype=dtype)
+
+
+@triton.jit
 def _min_red(val, x, **kwargs):
     return tl.minimum(val, tl.min(x))
 
@@ -74,8 +79,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
@@ -91,7 +96,8 @@ class Model(nn.Module):
         res_red = reduce_last_dim(
             res_gn,
             out_dtype=res_gn.dtype,
-            reduction=_min_red,
+            init_val=_min_init_val,
+            reduction_op=_min_red,
             keep_dim=True,
         )
 

--- a/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
+++ b/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
@@ -11,7 +11,6 @@ import triton.language as tl
 from triton_cpu_utils import gelu
 from triton_cpu_utils import pack_weights_for_sfc_matmul
 from triton_cpu_utils import reduce_first_dim
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
 
 
@@ -49,14 +48,9 @@ def _kernel_first_dim(inp_ptr, out_ptr, N, BLOCK_SIZE_N: tl.constexpr):
 
 
 @triton.jit
-def _max_last_dim(val, x, **kwargs):
-    return tl.maximum(val, tl.max(x))
-
-
-@triton.jit
-def _max_epi_last_dim(val, **kwargs):
+def _max_epi_last_dim(**kwargs):
     # mean of a single element -> the max_dim=1 benchmark config is a degenerate case that just returns zeros.
-    return gelu(val - val)
+    return 0.0
 
 
 class Model(nn.Module):
@@ -78,17 +72,17 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
-            x,
-            self._weight_packed,
-            bias=self._bias,
-            trunc_output=False,
-            b_is_prepacked=True,
-            c_is_owned=True,
-            blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
-        )
-
         if self.max_dim == 0:
+            res_mm = sfc_matmul(
+                x,
+                self._weight_packed,
+                bias=self._bias,
+                trunc_output=False,
+                b_is_prepacked=True,
+                c_is_owned=True,
+                blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
+            )
+
             res_max = reduce_first_dim(
                 res_mm,
                 out_dtype=res_mm.dtype,  # keep it in f32
@@ -111,12 +105,13 @@ class Model(nn.Module):
             return out
 
         assert self.max_dim == 1, "max_dim must be either 0 or 1"
-        res_max = reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=_max_last_dim,
-            post_op=_max_epi_last_dim,
+        return sfc_matmul(
+            x,
+            self._weight_packed,
+            bias=self._bias,
+            reduce_last_dim=True,
+            reduction_post_op=_max_epi_last_dim,
             keep_dim=True,
+            b_is_prepacked=True,
+            blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        return res_max

--- a/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
+++ b/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
@@ -15,6 +15,11 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
+def _max_init_val(dtype, BLOCK_SIZE_N, **kwargs):
+    return tl.full([BLOCK_SIZE_N], float("-inf"), dtype=dtype)
+
+
+@triton.jit
 def _max_first_dim(vals, x, **kwargs):
     return tl.maximum(vals, x)
 
@@ -48,9 +53,9 @@ def _kernel_first_dim(inp_ptr, out_ptr, N, BLOCK_SIZE_N: tl.constexpr):
 
 
 @triton.jit
-def _max_epi_last_dim(**kwargs):
+def _max_epi_last_dim(val, **kwargs):
     # mean of a single element -> the max_dim=1 benchmark config is a degenerate case that just returns zeros.
-    return 0.0
+    return val * 0.0
 
 
 class Model(nn.Module):
@@ -86,7 +91,8 @@ class Model(nn.Module):
             res_max = reduce_first_dim(
                 res_mm,
                 out_dtype=res_mm.dtype,  # keep it in f32
-                reduction=_max_first_dim,
+                init_val=_max_init_val,
+                reduction_op=_max_first_dim,
                 keep_dim=True,
             )
             M, N = res_max.shape

--- a/backends/triton/cpu/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.py
+++ b/backends/triton/cpu/KernelBench/level2/84_Gemm_BatchNorm_Scaling_Softmax.py
@@ -9,7 +9,6 @@ import triton
 
 from triton_cpu_utils import pack_weights_for_sfc_matmul
 from triton_cpu_utils import sfc_matmul
-from triton_cpu_utils import softmax
 
 
 @triton.jit
@@ -45,15 +44,12 @@ class Model(nn.Module):
             assert self.bn.affine, "BatchNorm must have affine=True"
 
         # eval()-mode BatchNorm1d and scaling with 1.0 merged into epilogue, see above.
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
-            trunc_output=False,
-            c_is_owned=True,
+            softmax_last_dim=True,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        return softmax(res_mm, out_dtype=x.dtype)

--- a/backends/triton/cpu/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.py
+++ b/backends/triton/cpu/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.py
@@ -55,8 +55,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.py
@@ -62,10 +62,10 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=_epilogue,
             post_op_arg=self._bias_extra,
             trunc_output=False,
+            b_is_prepacked=True,
             c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
+++ b/backends/triton/cpu/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
@@ -60,8 +60,8 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             post_op=self._epilogue_fun,
             post_op_arg=self._bias_extra,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
+++ b/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
@@ -41,7 +41,7 @@ class Model(nn.Module):
 
         self._weight_packed = None
         self._bias = None
-        self._red1_fun = _red_block
+        self._red_block_fun = _red_block
 
     def forward(self, x):
         if self._weight_packed is None:
@@ -59,8 +59,8 @@ class Model(nn.Module):
             bias=self._bias,
             b_is_prepacked=True,
             reduce_last_dim=True,
-            reduction_init_op=_red_init,
-            reduction_block_op=self._red1_fun,
+            reduction_init_val=_red_init,
+            reduction_block_op=self._red_block_fun,
             reduction_combine_op=_red_combine,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
+++ b/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
@@ -9,8 +9,17 @@ import triton.language as tl
 
 from triton_cpu_utils import gelu
 from triton_cpu_utils import pack_weights_for_sfc_matmul
-from triton_cpu_utils import reduce_last_dim
 from triton_cpu_utils import sfc_matmul
+
+
+@triton.jit
+def _red_init(dtype, BLOCK_SIZE_M, **kwargs):
+    return tl.full([BLOCK_SIZE_M], float("-inf"), dtype=dtype)
+
+
+@triton.jit
+def _red_combine(a, b, **kwargs):
+    return tl.maximum(a, b)
 
 
 class Model(nn.Module):
@@ -24,15 +33,15 @@ class Model(nn.Module):
         sf_val = tl.constexpr(scale_factor)
 
         @triton.jit
-        def _red(val, x, BLOCK_SIZE_N, **kwargs):
-            x = x.reshape([BLOCK_SIZE_N // kern_sz, kern_sz])
-            xmean = tl.sum(x, axis=1) / kern_sz
+        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N, **kwargs):
+            block = block.reshape([BLOCK_SIZE_M, BLOCK_SIZE_N // kern_sz, kern_sz])
+            xmean = tl.sum(block, axis=2) / kern_sz
             xmean = gelu(xmean) * sf_val
-            return tl.maximum(val, tl.max(xmean))
+            return tl.max(xmean, axis=1)
 
         self._weight_packed = None
         self._bias = None
-        self._red_fun = _red
+        self._red1_fun = _red_block
 
     def forward(self, x):
         if self._weight_packed is None:
@@ -44,18 +53,14 @@ class Model(nn.Module):
             )
             self._bias = self.matmul.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             bias=self._bias,
             b_is_prepacked=True,
-            trunc_output=False,
-            c_is_owned=True,
+            reduce_last_dim=True,
+            reduction_init_op=_red_init,
+            reduction_block_op=self._red1_fun,
+            reduction_combine_op=_red_combine,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
-        )
-
-        return reduce_last_dim(
-            res_mm,
-            out_dtype=x.dtype,
-            reduction=self._red_fun,
         )

--- a/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
+++ b/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
@@ -57,10 +57,10 @@ class Model(nn.Module):
             x,
             self._weight_packed,
             bias=self._bias,
-            b_is_prepacked=True,
             reduce_last_dim=True,
             reduction_init_val=_red_init,
             reduction_block_op=self._red_block_fun,
             reduction_combine_op=_red_combine,
+            b_is_prepacked=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )

--- a/backends/triton/cpu/KernelBench/level2/99_Matmul_GELU_Softmax.py
+++ b/backends/triton/cpu/KernelBench/level2/99_Matmul_GELU_Softmax.py
@@ -9,7 +9,6 @@ import triton
 from triton_cpu_utils import gelu
 from triton_cpu_utils import pack_weights_for_sfc_matmul
 from triton_cpu_utils import sfc_matmul
-from triton_cpu_utils import softmax
 
 
 @triton.jit
@@ -34,15 +33,12 @@ class Model(nn.Module):
             )
             self._bias = self.linear.bias.data.to(dtype=x.dtype)
 
-        res_mm = sfc_matmul(
+        return sfc_matmul(
             x,
             self._weight_packed,
             bias=self._bias,
             post_op=_epilogue,
-            trunc_output=False,
+            softmax_last_dim=True,
             b_is_prepacked=True,
-            c_is_owned=True,
             blocking_factor_k=triton.next_power_of_2(max(1, x.shape[1] // 4096)),
         )
-
-        return softmax(res_mm, x.dtype)

--- a/backends/utils/triton_cpu_utils/reduction.py
+++ b/backends/utils/triton_cpu_utils/reduction.py
@@ -10,7 +10,8 @@ def _reduce_last_dim_kernel(
     M,
     N,
     BLOCK_SIZE_N: tl.constexpr,
-    REDUCTION: tl.constexpr,
+    INIT_VAL: tl.constexpr,
+    REDUCTION_OP: tl.constexpr,
     POST_OP: tl.constexpr,
 ):
     inp_desc = tl.make_tensor_descriptor(
@@ -20,11 +21,11 @@ def _reduce_last_dim_kernel(
         block_shape=[1, BLOCK_SIZE_N],
     )
 
-    row_val = tl.zeros([], dtype=inp_ptr.type.element_ty)
+    row_val = INIT_VAL(dtype=inp_ptr.type.element_ty)
     m = tl.program_id(0)
     for n in range(0, N, BLOCK_SIZE_N):
         x = inp_desc.load([m, n]).reshape([BLOCK_SIZE_N])
-        row_val = REDUCTION(row_val, x, BLOCK_SIZE_N=BLOCK_SIZE_N)
+        row_val = REDUCTION_OP(row_val, x, BLOCK_SIZE_N=BLOCK_SIZE_N)
 
     row_val = POST_OP(row_val, N=N)
 
@@ -38,7 +39,8 @@ def _reduce_first_dim_kernel(
     M,
     N,
     BLOCK_SIZE_N: tl.constexpr,
-    REDUCTION: tl.constexpr,
+    INIT_VAL: tl.constexpr,
+    REDUCTION_OP: tl.constexpr,
     POST_OP: tl.constexpr,
 ):
     inp_desc = tl.make_tensor_descriptor(
@@ -54,11 +56,11 @@ def _reduce_first_dim_kernel(
         block_shape=[1, BLOCK_SIZE_N],
     )
 
-    col_vals = tl.zeros([BLOCK_SIZE_N], dtype=inp_ptr.type.element_ty)
+    col_vals = INIT_VAL(dtype=inp_ptr.type.element_ty, BLOCK_SIZE_N=BLOCK_SIZE_N)
     n = tl.program_id(0) * BLOCK_SIZE_N
     for m in range(0, M):
         x = inp_desc.load([m, n]).reshape([BLOCK_SIZE_N])
-        col_vals = REDUCTION(col_vals, x, BLOCK_SIZE_N=BLOCK_SIZE_N)
+        col_vals = REDUCTION_OP(col_vals, x, BLOCK_SIZE_N=BLOCK_SIZE_N)
 
     col_vals = POST_OP(col_vals, M=M)
 
@@ -72,7 +74,19 @@ def _no_post_op(x, **kwargs):
     return x
 
 
-def reduce_last_dim(inp, out_dtype, reduction, post_op=None, keep_dim=False):
+@triton.jit
+def _default_init_val_last_dim(dtype, **kwargs):
+    return tl.zeros([], dtype=dtype)
+
+
+@triton.jit
+def _default_init_val_first_dim(dtype, BLOCK_SIZE_N, **kwargs):
+    return tl.zeros([BLOCK_SIZE_N], dtype=dtype)
+
+
+def reduce_last_dim(
+    inp, out_dtype, reduction_op, init_val=None, post_op=None, keep_dim=False
+):
     assert inp.ndim == 2, "Input tensor must be 2D"
     M, N = inp.shape
     out_shape = (M, 1) if keep_dim else (M,)
@@ -85,14 +99,17 @@ def reduce_last_dim(inp, out_dtype, reduction, post_op=None, keep_dim=False):
         M,
         N,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
-        REDUCTION=reduction,
+        INIT_VAL=init_val or _default_init_val_last_dim,
+        REDUCTION_OP=reduction_op,
         POST_OP=post_op or _no_post_op,
         assume_in_bounds=True,
     )
     return out
 
 
-def reduce_first_dim(inp, out_dtype, reduction, post_op=None, keep_dim=False):
+def reduce_first_dim(
+    inp, out_dtype, reduction_op, init_val=None, post_op=None, keep_dim=False
+):
     assert inp.ndim == 2, "Input tensor must be 2D"
     M, N = inp.shape
     out_shape = (1, N) if keep_dim else (N,)
@@ -105,7 +122,8 @@ def reduce_first_dim(inp, out_dtype, reduction, post_op=None, keep_dim=False):
         M,
         N,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
-        REDUCTION=reduction,
+        INIT_VAL=init_val or _default_init_val_first_dim,
+        REDUCTION_OP=reduction_op,
         POST_OP=post_op or _no_post_op,
         assume_in_bounds=True,
     )

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -145,6 +145,7 @@ def _sfc_matmul_kernel(
     POST_OP_HAS_ARG: tl.constexpr,
     REDUCE_LAST_DIM: tl.constexpr,
     REDUCTION_BLOCK_OP: tl.constexpr,
+    SOFTMAX_LAST_DIM: tl.constexpr,
 ):
     VNNI: tl.constexpr = 32 // b_ptr.type.element_ty.primitive_bitwidth
 
@@ -172,12 +173,12 @@ def _sfc_matmul_kernel(
         block_shape=(1, 1, BLOCK_SIZE_K // VNNI, BLOCK_SIZE_N * VNNI),
     )
 
-    if BLOCKING_FACTOR_K > 1:
+    if BLOCKING_FACTOR_K > 1 or SOFTMAX_LAST_DIM:
         ctmp_desc = tl.make_tensor_descriptor(
             base=ctmp_ptr,
-            shape=(BLOCKS_M * BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
-            strides=(BLOCK_SIZE_M * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
-            block_shape=(1, BLOCK_SIZE_M, BLOCK_SIZE_N),
+            shape=(BLOCKS_M, BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
+            strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_M * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
+            block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N),
         )
 
     c = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=ACCUM_DTYPE)
@@ -194,10 +195,14 @@ def _sfc_matmul_kernel(
         c = tl.dot(a, b, acc=c, out_dtype=ACCUM_DTYPE)
 
     if not IS_FIRST_K_BLOCK:
-        c += ctmp_desc.load([pid, 0, 0]).reshape((BLOCK_SIZE_M, BLOCK_SIZE_N))
+        c += ctmp_desc.load([block_m, block_n, 0, 0]).reshape(
+            (BLOCK_SIZE_M, BLOCK_SIZE_N)
+        )
 
     if not IS_LAST_K_BLOCK:
-        ctmp_desc.store([pid, 0, 0], c.reshape((1, BLOCK_SIZE_M, BLOCK_SIZE_N)))
+        ctmp_desc.store(
+            [block_m, block_n, 0, 0], c.reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+        )
         return
 
     if HAS_BIAS:
@@ -237,6 +242,26 @@ def _sfc_matmul_kernel(
         # Transposed write to intermediate buffer for final reduction
         cred = cred.reshape((1, BLOCK_SIZE_M))
         cred_desc.store([block_n, block_m * BLOCK_SIZE_M], cred)
+        return
+
+    if SOFTMAX_LAST_DIM:
+        cmax = tl.max(c, axis=1)
+        cexp = tl.exp(c - cmax[:, None])
+        cexpsum = tl.sum(cexp, axis=1)
+        cred = tl.interleave(cmax, cexpsum)
+        cred_desc = tl.make_tensor_descriptor(
+            base=cred_ptr,
+            shape=(BLOCKS_N, 2 * M),
+            strides=(2 * M, 1),
+            block_shape=(1, 2 * BLOCK_SIZE_M),
+        )
+        # Transposed write of block stats to intermediate buffer for final normalization.
+        cred = cred.reshape((1, 2 * BLOCK_SIZE_M))
+        cred_desc.store([block_n, block_m * 2 * BLOCK_SIZE_M], cred)
+
+        # Also write the unnormalized GEMM result to the ctmp buffer for final normalization.
+        c = c.reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+        ctmp_desc.store([block_m, block_n, 0, 0], c)
         return
 
     # Normal writeback to output tensor
@@ -284,6 +309,67 @@ def _finish_reduction_kernel(
     )
     column_vals = REDUCTION_POST_OP(column_vals, M=M, N=N)
     out_desc.store([m], column_vals.to(out_ptr.type.element_ty))
+
+
+@triton.jit
+def _finish_softmax_kernel(
+    ctmp_ptr,
+    stat_ptr,
+    c_ptr,
+    M,
+    N,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    BLOCKS_M = M // BLOCK_SIZE_M
+    BLOCKS_N = N // BLOCK_SIZE_N
+
+    block_m = tl.program_id(axis=0)
+
+    stat_desc = tl.make_tensor_descriptor(
+        base=stat_ptr,
+        shape=(BLOCKS_N, 2 * M),
+        strides=(2 * M, 1),
+        block_shape=(1, 2 * BLOCK_SIZE_M),
+    )
+
+    # Note: Intermediate buffer is transposed: [N_BLOCKS, 2 * M]
+    col_max = tl.full([BLOCK_SIZE_M], float("-inf"), dtype=ctmp_ptr.type.element_ty)
+    col_sum = tl.zeros([BLOCK_SIZE_M], dtype=ctmp_ptr.type.element_ty)
+    for block_n in range(BLOCKS_N):
+        block_stats = stat_desc.load([block_n, block_m * 2 * BLOCK_SIZE_M]).reshape(
+            (BLOCK_SIZE_M, 2)
+        )
+        block_max, block_sum = tl.split(block_stats)
+        new_max = tl.maximum(col_max, block_max)
+        col_sum = col_sum * tl.exp(col_max - new_max) + block_sum * tl.exp(
+            block_max - new_max
+        )
+        col_max = new_max
+
+    ctmp_desc = tl.make_tensor_descriptor(
+        base=ctmp_ptr,
+        shape=(BLOCKS_M, BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
+        strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_M * BLOCK_SIZE_N, BLOCK_SIZE_N, 1),
+        block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N),
+    )
+
+    c_desc = tl.make_tensor_descriptor(
+        base=c_ptr,
+        shape=(BLOCKS_M, BLOCKS_N, BLOCK_SIZE_M, BLOCK_SIZE_N),
+        strides=(BLOCK_SIZE_M * N, BLOCK_SIZE_N, N, 1),
+        block_shape=(1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N),
+    )
+
+    for block_n in range(BLOCKS_N):
+        c = ctmp_desc.load([block_m, block_n, 0, 0]).reshape(
+            (BLOCK_SIZE_M, BLOCK_SIZE_N)
+        )
+        csoft = tl.exp(c - col_max[:, None]) / col_sum[:, None]
+        csoft = csoft.to(c_ptr.type.element_ty).reshape(
+            (1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N)
+        )
+        c_desc.store([block_m, block_n, 0, 0], csoft)
 
 
 @triton.jit
@@ -374,6 +460,7 @@ def _make_intermediate_buffers(
     accum_dtype,
     out_dtype,
     reduce_last_dim,
+    softmax_last_dim,
     b_is_prepacked,
     c_is_owned,
 ):
@@ -383,7 +470,13 @@ def _make_intermediate_buffers(
     ap_size = M * K * in_dtype.itemsize
     bp_size = K * N * in_dtype.itemsize if not b_is_prepacked else 0
     ctmp_size = M * N * accum_dtype.itemsize
-    cred_size = M * BLOCKS_N * accum_dtype.itemsize if reduce_last_dim else 0
+    cred_size = (
+        M * BLOCKS_N * accum_dtype.itemsize
+        if reduce_last_dim
+        else 2 * M * BLOCKS_N * accum_dtype.itemsize
+        if softmax_last_dim
+        else 0
+    )
     c_size = M * OUT_N * out_dtype.itemsize if c_is_owned else 0
 
     buf = torch.empty(
@@ -405,6 +498,12 @@ def _make_intermediate_buffers(
         .view(accum_dtype)
         .reshape((BLOCKS_N, M))  # Transpose intentional
         if reduce_last_dim
+        else buf[
+            ap_size + bp_size + ctmp_size : ap_size + bp_size + ctmp_size + cred_size
+        ]
+        .view(accum_dtype)
+        .reshape((BLOCKS_N, 2 * M))  # Transpose intentional
+        if softmax_last_dim
         else None
     )
     c = (
@@ -429,6 +528,7 @@ def sfc_matmul(
     reduction_combine_op=None,
     reduction_post_op=None,
     keep_dim=False,
+    softmax_last_dim=False,
     trunc_output=True,
     b_is_prepacked=False,
     c_is_owned=False,
@@ -440,6 +540,10 @@ def sfc_matmul(
     M, K = a.shape
     K2, N = b.shape
     assert K == K2, f"Incompatible K dimensions: {K} vs {K2}"
+
+    assert not (reduce_last_dim and softmax_last_dim), (
+        "Cannot reduce and softmax at the same time"
+    )
 
     # AMX
     BLOCK_SIZE_M = 32
@@ -473,6 +577,7 @@ def sfc_matmul(
         accum_dtype,
         out_dtype,
         reduce_last_dim,
+        softmax_last_dim,
         b_is_prepacked,
         c_is_owned,
     )
@@ -533,6 +638,7 @@ def sfc_matmul(
             POST_OP_HAS_ARG=post_op_arg is not None,
             REDUCE_LAST_DIM=reduce_last_dim,
             REDUCTION_BLOCK_OP=reduction_block_op or _default_reduction_op,
+            SOFTMAX_LAST_DIM=softmax_last_dim,
             assume_in_bounds=True,
         )
 
@@ -551,6 +657,18 @@ def sfc_matmul(
             REDUCTION_INIT_VAL=reduction_init_val or _default_init_val,
             REDUCTION_COMBINE_OP=reduction_combine_op or _default_combine_op,
             REDUCTION_POST_OP=reduction_post_op or _no_post_op,
+            assume_in_bounds=True,
+        )
+
+    if softmax_last_dim:
+        _finish_softmax_kernel[(BLOCKS_M,)](
+            ctmp,
+            cred,
+            c,
+            M,
+            N,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
             assume_in_bounds=True,
         )
 

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -124,6 +124,7 @@ def _sfc_matmul_kernel(
     b_ptr,
     c_ptr,
     ctmp_ptr,
+    cred_ptr,
     bias_ptr,
     post_op_arg_ptr,
     sfc_map_ptr,
@@ -142,6 +143,8 @@ def _sfc_matmul_kernel(
     HAS_BIAS: tl.constexpr,
     POST_OP: tl.constexpr,
     POST_OP_HAS_ARG: tl.constexpr,
+    REDUCE_LAST_DIM: tl.constexpr,
+    REDUCTION_BLOCK_OP: tl.constexpr,
 ):
     VNNI: tl.constexpr = 32 // b_ptr.type.element_ty.primitive_bitwidth
 
@@ -221,6 +224,22 @@ def _sfc_matmul_kernel(
     else:
         c = POST_OP(c)
 
+    if REDUCE_LAST_DIM:
+        cred = REDUCTION_BLOCK_OP(
+            c, BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N
+        )
+        cred_desc = tl.make_tensor_descriptor(
+            base=cred_ptr,
+            shape=(BLOCKS_N, M),
+            strides=(M, 1),
+            block_shape=(1, BLOCK_SIZE_M),
+        )
+        # Transposed write to intermediate buffer for final reduction
+        cred = cred.reshape((1, BLOCK_SIZE_M))
+        cred_desc.store([block_n, block_m * BLOCK_SIZE_M], cred)
+        return
+
+    # Normal writeback to output tensor
     c = c.to(OUT_DTYPE).reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
 
     c_desc = tl.make_tensor_descriptor(
@@ -233,8 +252,58 @@ def _sfc_matmul_kernel(
 
 
 @triton.jit
+def _finish_reduction_kernel(
+    inp_ptr,
+    out_ptr,
+    M,
+    N,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    REDUCTION_INIT_VAL: tl.constexpr,
+    REDUCTION_COMBINE_OP: tl.constexpr,
+    REDUCTION_POST_OP: tl.constexpr,
+):
+    BLOCKS_N = N // BLOCK_SIZE_N
+    inp_desc = tl.make_tensor_descriptor(
+        base=inp_ptr,
+        shape=(BLOCKS_N, M),
+        strides=(M, 1),
+        block_shape=(1, BLOCK_SIZE_M),
+    )
+    m = tl.program_id(0) * BLOCK_SIZE_M
+    column_vals = REDUCTION_INIT_VAL(inp_ptr.type.element_ty, BLOCK_SIZE_M=BLOCK_SIZE_M)
+    for block_n in range(BLOCKS_N):
+        block = inp_desc.load([block_n, m]).reshape((BLOCK_SIZE_M,))
+        column_vals = REDUCTION_COMBINE_OP(column_vals, block)
+
+    out_desc = tl.make_tensor_descriptor(
+        base=out_ptr,
+        shape=(M,),
+        strides=(1,),
+        block_shape=(BLOCK_SIZE_M,),
+    )
+    column_vals = REDUCTION_POST_OP(column_vals, M=M, N=N)
+    out_desc.store([m], column_vals.to(out_ptr.type.element_ty))
+
+
+@triton.jit
 def _no_post_op(x, **kwargs):
     return x
+
+
+@triton.jit
+def _default_init_val(dtype, BLOCK_SIZE_M, **kwargs):
+    return tl.zeros((BLOCK_SIZE_M,), dtype=dtype)
+
+
+@triton.jit
+def _default_reduction_op(x, **kwargs):
+    return x.sum(axis=1)
+
+
+@triton.jit
+def _default_combine_op(a, b, **kwargs):
+    return a + b
 
 
 def pack_weights_for_sfc_matmul(
@@ -297,14 +366,29 @@ def _make_sfc_tensor(x, y, dtype=torch.int32, device="cpu"):
 
 @thread_lru_cache()
 def _make_intermediate_buffers(
-    M, N, K, in_dtype, accum_dtype, out_dtype, b_is_prepacked, c_is_owned
+    M,
+    N,
+    K,
+    BLOCK_SIZE_N,
+    in_dtype,
+    accum_dtype,
+    out_dtype,
+    reduce_last_dim,
+    b_is_prepacked,
+    c_is_owned,
 ):
+    BLOCKS_N = N // BLOCK_SIZE_N
+    OUT_N = 1 if reduce_last_dim else N
+
     ap_size = M * K * in_dtype.itemsize
     bp_size = K * N * in_dtype.itemsize if not b_is_prepacked else 0
     ctmp_size = M * N * accum_dtype.itemsize
-    c_size = M * N * out_dtype.itemsize if c_is_owned else 0
+    cred_size = M * BLOCKS_N * accum_dtype.itemsize if reduce_last_dim else 0
+    c_size = M * OUT_N * out_dtype.itemsize if c_is_owned else 0
 
-    buf = torch.empty(ap_size + bp_size + ctmp_size + c_size, dtype=torch.uint8)
+    buf = torch.empty(
+        ap_size + bp_size + ctmp_size + cred_size + c_size, dtype=torch.uint8
+    )
     ap = buf[:ap_size].view(in_dtype).reshape((M, K))
     bp = (
         buf[ap_size : ap_size + bp_size].view(in_dtype).reshape((K, N))
@@ -316,12 +400,21 @@ def _make_intermediate_buffers(
         .view(accum_dtype)
         .reshape((M, N))
     )
+    cred = (
+        buf[ap_size + bp_size + ctmp_size : ap_size + bp_size + ctmp_size + cred_size]
+        .view(accum_dtype)
+        .reshape((BLOCKS_N, M))  # Transpose intentional
+        if reduce_last_dim
+        else None
+    )
     c = (
-        buf[ap_size + bp_size + ctmp_size :].view(out_dtype).reshape((M, N))
+        buf[ap_size + bp_size + ctmp_size + cred_size :]
+        .view(out_dtype)
+        .reshape((M, OUT_N))
         if c_is_owned
         else None
     )
-    return ap, bp, ctmp, c
+    return ap, bp, ctmp, cred, c
 
 
 def sfc_matmul(
@@ -330,6 +423,12 @@ def sfc_matmul(
     bias=None,
     post_op=None,
     post_op_arg=None,
+    reduce_last_dim=False,
+    reduction_init_val=None,
+    reduction_block_op=None,
+    reduction_combine_op=None,
+    reduction_post_op=None,
+    keep_dim=False,
     trunc_output=True,
     b_is_prepacked=False,
     c_is_owned=False,
@@ -365,13 +464,27 @@ def sfc_matmul(
     accum_dtype = _get_accum_dtype(a.dtype)
     out_dtype = a.dtype if trunc_output else accum_dtype
 
-    ap, bp, ctmp, c = _make_intermediate_buffers(
-        M, N, K, a.dtype, accum_dtype, out_dtype, b_is_prepacked, c_is_owned
+    ap, bp, ctmp, cred, c = _make_intermediate_buffers(
+        M,
+        N,
+        K,
+        BLOCK_SIZE_N,
+        a.dtype,
+        accum_dtype,
+        out_dtype,
+        reduce_last_dim,
+        b_is_prepacked,
+        c_is_owned,
     )
     if b_is_prepacked:
         bp = b
     if not c_is_owned:
-        c = torch.empty((M, N), device=a.device, dtype=out_dtype)
+        if not reduce_last_dim:
+            c = torch.empty((M, N), device=a.device, dtype=out_dtype)
+        elif keep_dim:
+            c = torch.empty((M, 1), device=a.device, dtype=out_dtype)
+        else:
+            c = torch.empty((M,), device=a.device, dtype=out_dtype)
 
     num_blocks = max(
         BLOCKS_M * BLOCKS_K, BLOCKS_K * BLOCKS_N if not b_is_prepacked else 0
@@ -399,6 +512,7 @@ def sfc_matmul(
             bp,
             c,
             ctmp,
+            cred,
             bias,
             post_op_arg,
             sfc_map_mn,
@@ -417,6 +531,30 @@ def sfc_matmul(
             HAS_BIAS=bias is not None,
             POST_OP=post_op if post_op is not None else _no_post_op,
             POST_OP_HAS_ARG=post_op_arg is not None,
+            REDUCE_LAST_DIM=reduce_last_dim,
+            REDUCTION_BLOCK_OP=reduction_block_op
+            if reduction_block_op is not None
+            else _default_reduction_op,
+            assume_in_bounds=True,
+        )
+
+    if reduce_last_dim:
+        _finish_reduction_kernel[(BLOCKS_M,)](
+            cred,
+            c,
+            M,
+            N,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            REDUCTION_INIT_VAL=reduction_init_val
+            if reduction_init_val is not None
+            else _default_init_val,
+            REDUCTION_COMBINE_OP=reduction_combine_op
+            if reduction_combine_op is not None
+            else _default_combine_op,
+            REDUCTION_POST_OP=reduction_post_op
+            if reduction_post_op is not None
+            else _no_post_op,
             assume_in_bounds=True,
         )
 

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -537,6 +537,10 @@ def sfc_matmul(
         )
 
     if reduce_last_dim:
+        if M % 256 == 0:
+            # Go a bit wider
+            BLOCK_SIZE_M = 256
+            BLOCKS_M = M // BLOCK_SIZE_M
         _finish_reduction_kernel[(BLOCKS_M,)](
             cred,
             c,

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -245,6 +245,10 @@ def _sfc_matmul_kernel(
         return
 
     if SOFTMAX_LAST_DIM:
+        # Write the unnormalized GEMM result to the ctmp buffer
+        corig = c.reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
+        ctmp_desc.store([block_m, block_n, 0, 0], corig)
+
         cmax = tl.max(c, axis=1)
         cexp = tl.exp(c - cmax[:, None])
         cexpsum = tl.sum(cexp, axis=1)
@@ -255,13 +259,9 @@ def _sfc_matmul_kernel(
             strides=(2 * M, 1),
             block_shape=(1, 2 * BLOCK_SIZE_M),
         )
-        # Transposed write of block stats to intermediate buffer for final normalization.
+        # Transposed write of block stats to intermediate buffer for final normalization
         cred = cred.reshape((1, 2 * BLOCK_SIZE_M))
         cred_desc.store([block_n, block_m * 2 * BLOCK_SIZE_M], cred)
-
-        # Also write the unnormalized GEMM result to the ctmp buffer for final normalization.
-        c = c.reshape((1, 1, BLOCK_SIZE_M, BLOCK_SIZE_N))
-        ctmp_desc.store([block_m, block_n, 0, 0], c)
         return
 
     # Normal writeback to output tensor

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -529,12 +529,10 @@ def sfc_matmul(
             ACCUM_DTYPE=_torch_to_triton_dtype(accum_dtype),
             OUT_DTYPE=_torch_to_triton_dtype(out_dtype),
             HAS_BIAS=bias is not None,
-            POST_OP=post_op if post_op is not None else _no_post_op,
+            POST_OP=post_op or _no_post_op,
             POST_OP_HAS_ARG=post_op_arg is not None,
             REDUCE_LAST_DIM=reduce_last_dim,
-            REDUCTION_BLOCK_OP=reduction_block_op
-            if reduction_block_op is not None
-            else _default_reduction_op,
+            REDUCTION_BLOCK_OP=reduction_block_op or _default_reduction_op,
             assume_in_bounds=True,
         )
 
@@ -546,15 +544,9 @@ def sfc_matmul(
             N,
             BLOCK_SIZE_M=BLOCK_SIZE_M,
             BLOCK_SIZE_N=BLOCK_SIZE_N,
-            REDUCTION_INIT_VAL=reduction_init_val
-            if reduction_init_val is not None
-            else _default_init_val,
-            REDUCTION_COMBINE_OP=reduction_combine_op
-            if reduction_combine_op is not None
-            else _default_combine_op,
-            REDUCTION_POST_OP=reduction_post_op
-            if reduction_post_op is not None
-            else _no_post_op,
+            REDUCTION_INIT_VAL=reduction_init_val or _default_init_val,
+            REDUCTION_COMBINE_OP=reduction_combine_op or _default_combine_op,
+            REDUCTION_POST_OP=reduction_post_op or _no_post_op,
             assume_in_bounds=True,
         )
 


### PR DESCRIPTION
Gives better control over intermediate buffers and uses less memory in case of reductions (full matmul result doesn't have to be stored).

Approach (simplified):
1. Perform block reduction on a result tile after matmul and elementwise post-op.
2. Store the partial reduction result into a transposed intermediate buffer of shape `[N // BLOCK_SIZE_N, M]`.
3. Finish reduction in a separate kernel. Each program handles a chuck of M. We iterate over the N blocks and reduce vertically. The chunk is then written to the `[M, 1]` result tensor.

Also: Make the initial value for reductions configurable, to fix an adjacent issue with min/max reduction which shouldn't start with zeros.