### PR TITLE
Remove mlir-python-bindings override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,9 +115,6 @@ conflicts = [
     { extra = "triton-cpu" },
   ],
 ]
-override-dependencies = [
-  "mlir-python-bindings==20260728+5e91f5d57",
-]
 
 [tool.uv.sources]
 torch = { index = "pytorch" }


### PR DESCRIPTION
Realigns the MLIR binding's version with Lighthouse as all core MLIR functionality goes through it now.