### PR TITLE
[TritonCPU] Bump after bump

### DIFF
--- a/backends/triton/cpu/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.py
+++ b/backends/triton/cpu/KernelBench/level2/14_Gemm_Divide_Sum_Scaling.py
@@ -27,7 +27,7 @@ class Model(nn.Module):
         sf_val = tl.constexpr(scaling_factor)
 
         @triton.jit
-        def _red_epilogue(x, **kwargs):
+        def _red_epilogue(x, M, N):
             x *= sf_val
             return x
 

--- a/backends/triton/cpu/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.py
+++ b/backends/triton/cpu/KernelBench/level2/22_Matmul_Scale_ResidualAdd_Clamp_LogSumExp_Mish.py
@@ -13,12 +13,12 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _red_block(block, **kwargs):
+def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N):
     return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
-def _red_epi(val, **kwargs):
+def _red_epi(val, M, N):
     val = tl.log(val)  # second part of logsumexp
     return val * mish(val)
 

--- a/backends/triton/cpu/KernelBench/level2/33_Gemm_Scale_BatchNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/33_Gemm_Scale_BatchNorm.py
@@ -13,7 +13,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),

--- a/backends/triton/cpu/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/37_Matmul_Swish_Sum_GroupNorm.py
@@ -14,7 +14,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),

--- a/backends/triton/cpu/KernelBench/level2/39_Gemm_Scale_BatchNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/39_Gemm_Scale_BatchNorm.py
@@ -13,7 +13,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),

--- a/backends/triton/cpu/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.py
+++ b/backends/triton/cpu/KernelBench/level2/45_Gemm_Sigmoid_LogSumExp.py
@@ -17,12 +17,12 @@ def _mm1_epi(x):
 
 
 @triton.jit
-def _red_block(block, **kwargs):
+def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N):
     return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
-def _red_epi(val, **kwargs):
+def _red_epi(val, M, N):
     return tl.log(val)  # second part of logsumexp
 
 

--- a/backends/triton/cpu/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.py
+++ b/backends/triton/cpu/KernelBench/level2/51_Gemm_Subtract_GlobalAvgPool_LogSumExp_GELU_ResidualAdd.py
@@ -14,7 +14,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),
@@ -26,7 +26,7 @@ def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
 
 
 @triton.jit
-def _red_epi(val, N, **kwargs):
+def _red_epi(val, M, N):
     return gelu(val / N)
 
 

--- a/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
+++ b/backends/triton/cpu/KernelBench/level2/55_Matmul_MaxPool_Sum_Scale.py
@@ -21,13 +21,13 @@ class Model(nn.Module):
         sf_val = tl.constexpr(scale_factor)
 
         @triton.jit
-        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N, **kwargs):
+        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N):
             block = block.reshape([BLOCK_SIZE_M, BLOCK_SIZE_N // kern_sz, kern_sz])
             xm = tl.max(block, axis=2)
             return tl.sum(xm, axis=1)
 
         @triton.jit
-        def _red_epi(val, **kwargs):
+        def _red_epi(val, M, N):
             val *= sf_val
             return val
 

--- a/backends/triton/cpu/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.py
+++ b/backends/triton/cpu/KernelBench/level2/64_Gemm_LogSumExp_LeakyReLU_LeakyReLU_GELU_GELU.py
@@ -13,12 +13,12 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _red_block(block, **kwargs):
+def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N):
     return tl.sum(tl.exp(block), axis=1)
 
 
 @triton.jit
-def _red_epi(val, **kwargs):
+def _red_epi(val, M, N):
     NEG_SLOPE: tl.constexpr = 0.01
     val = tl.log(val)  # second part of logsumexp
     val = tl.where(val >= 0, val, val * NEG_SLOPE)  # leaky relu

--- a/backends/triton/cpu/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.py
+++ b/backends/triton/cpu/KernelBench/level2/75_Gemm_GroupNorm_Min_BiasAdd.py
@@ -15,12 +15,12 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _min_init_val(dtype, **kwargs):
+def _min_init_val(dtype):
     return tl.full([], float("inf"), dtype=dtype)
 
 
 @triton.jit
-def _min_red(val, x, **kwargs):
+def _min_red(val, x, BLOCK_SIZE_N):
     return tl.minimum(val, tl.min(x))
 
 

--- a/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
+++ b/backends/triton/cpu/KernelBench/level2/80_Gemm_Max_Subtract_GELU.py
@@ -15,12 +15,12 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _max_init_val(dtype, BLOCK_SIZE_N, **kwargs):
+def _max_init_val(dtype, BLOCK_SIZE_N):
     return tl.full([BLOCK_SIZE_N], float("-inf"), dtype=dtype)
 
 
 @triton.jit
-def _max_first_dim(vals, x, **kwargs):
+def _max_first_dim(vals, x, BLOCK_SIZE_N):
     return tl.maximum(vals, x)
 
 
@@ -53,7 +53,7 @@ def _kernel_first_dim(inp_ptr, out_ptr, N, BLOCK_SIZE_N: tl.constexpr):
 
 
 @triton.jit
-def _max_epi_last_dim(val, **kwargs):
+def _max_epi_last_dim(val, M, N):
     # mean of a single element -> the max_dim=1 benchmark config is a degenerate case that just returns zeros.
     return val * 0.0
 

--- a/backends/triton/cpu/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.py
+++ b/backends/triton/cpu/KernelBench/level2/88_Gemm_GroupNorm_Swish_Multiply_Swish.py
@@ -14,7 +14,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _norm_epilogue(x, g, c, post_op_arg_ptr, C, group_size, BLOCK_SIZE_C, **kwargs):
+def _norm_epilogue(x, n, g, c, post_op_arg_ptr, N, C, group_size, BLOCK_SIZE_C):
     desc = tl.make_tensor_descriptor(
         post_op_arg_ptr,
         shape=[C],

--- a/backends/triton/cpu/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.py
+++ b/backends/triton/cpu/KernelBench/level2/94_Gemm_BiasAdd_Hardtanh_Mish_GroupNorm.py
@@ -15,7 +15,7 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),

--- a/backends/triton/cpu/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.py
+++ b/backends/triton/cpu/KernelBench/level2/95_Matmul_Add_Swish_Tanh_GELU_Hardtanh.py
@@ -15,7 +15,7 @@ from triton_cpu_utils import tanh
 
 
 @triton.jit
-def _epilogue(x, block_n, post_op_arg_ptr, N, BLOCK_SIZE_N, **kwargs):
+def _epilogue(x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N):
     desc = tl.make_tensor_descriptor(
         base=post_op_arg_ptr,
         shape=(N,),

--- a/backends/triton/cpu/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
+++ b/backends/triton/cpu/KernelBench/level2/97_Matmul_BatchNorm_BiasAdd_Divide_Swish.py
@@ -30,7 +30,9 @@ class Model(nn.Module):
         div_val = tl.constexpr(divide_value)
 
         @triton.jit
-        def _epilogue(x, post_op_arg_ptr, **kwargs):
+        def _epilogue(
+            x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N
+        ):
             bias_val = tl.load(post_op_arg_ptr).to(x.dtype)
             x += bias_val
             # After the bias addition, the next op is an untrained BatchNorm1d in eval mode, with affine=True and eps=1e-5, which simplifies to multiplication with 1/sqrt(1 + eps).

--- a/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
+++ b/backends/triton/cpu/KernelBench/level2/98_Matmul_AvgPool_GELU_Scale_Max.py
@@ -13,12 +13,12 @@ from triton_cpu_utils import sfc_matmul
 
 
 @triton.jit
-def _red_init(dtype, BLOCK_SIZE_M, **kwargs):
+def _red_init(dtype, BLOCK_SIZE_M):
     return tl.full([BLOCK_SIZE_M], float("-inf"), dtype=dtype)
 
 
 @triton.jit
-def _red_combine(a, b, **kwargs):
+def _red_combine(a, b):
     return tl.maximum(a, b)
 
 
@@ -33,7 +33,7 @@ class Model(nn.Module):
         sf_val = tl.constexpr(scale_factor)
 
         @triton.jit
-        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N, **kwargs):
+        def _red_block(block, BLOCK_SIZE_M, BLOCK_SIZE_N):
             block = block.reshape([BLOCK_SIZE_M, BLOCK_SIZE_N // kern_sz, kern_sz])
             xmean = tl.sum(block, axis=2) / kern_sz
             xmean = gelu(xmean) * sf_val

--- a/backends/utils/triton_cpu_utils/reduction.py
+++ b/backends/utils/triton_cpu_utils/reduction.py
@@ -70,17 +70,22 @@ def _reduce_first_dim_kernel(
 
 
 @triton.jit
-def _no_post_op(x, **kwargs):
+def _no_post_op_last_dim(x, N):
     return x
 
 
 @triton.jit
-def _default_init_val_last_dim(dtype, **kwargs):
+def _default_init_val_last_dim(dtype):
     return tl.zeros([], dtype=dtype)
 
 
 @triton.jit
-def _default_init_val_first_dim(dtype, BLOCK_SIZE_N, **kwargs):
+def _no_post_op_first_dim(x, M):
+    return x
+
+
+@triton.jit
+def _default_init_val_first_dim(dtype, BLOCK_SIZE_N):
     return tl.zeros([BLOCK_SIZE_N], dtype=dtype)
 
 
@@ -101,7 +106,7 @@ def reduce_last_dim(
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         INIT_VAL=init_val or _default_init_val_last_dim,
         REDUCTION_OP=reduction_op,
-        POST_OP=post_op or _no_post_op,
+        POST_OP=post_op or _no_post_op_last_dim,
         assume_in_bounds=True,
     )
     return out
@@ -124,7 +129,7 @@ def reduce_first_dim(
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         INIT_VAL=init_val or _default_init_val_first_dim,
         REDUCTION_OP=reduction_op,
-        POST_OP=post_op or _no_post_op,
+        POST_OP=post_op or _no_post_op_first_dim,
         assume_in_bounds=True,
     )
     return out
@@ -256,6 +261,16 @@ def _affine_groupnorm_2d_kernel(
         )
 
 
+@triton.jit
+def _no_post_op_norm(y):
+    return y
+
+
+@triton.jit
+def _no_post_op_with_args(y, n, g, c, post_op_arg_ptr, N, C, group_size, BLOCK_SIZE_C):
+    return y
+
+
 def groupnorm(
     inp,
     out_dtype,
@@ -289,7 +304,8 @@ def groupnorm(
         num_groups,
         eps,
         BLOCK_SIZE_C=BLOCK_SIZE_C,
-        POST_OP=post_op or _no_post_op,
+        POST_OP=post_op
+        or (_no_post_op_norm if post_op_arg is None else _no_post_op_with_args),
         POST_OP_HAS_ARG=post_op_arg is not None,
         assume_in_bounds=True,
     )

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -373,23 +373,35 @@ def _finish_softmax_kernel(
 
 
 @triton.jit
-def _no_post_op(x, **kwargs):
+def _no_post_op(x):
     return x
 
 
 @triton.jit
-def _default_init_val(dtype, BLOCK_SIZE_M, **kwargs):
+def _no_post_op_with_arg(
+    x, block_m, block_n, post_op_arg_ptr, M, N, BLOCK_SIZE_M, BLOCK_SIZE_N
+):
+    return x
+
+
+@triton.jit
+def _default_init_val(dtype, BLOCK_SIZE_M):
     return tl.zeros((BLOCK_SIZE_M,), dtype=dtype)
 
 
 @triton.jit
-def _default_reduction_op(x, **kwargs):
+def _default_reduction_op(x, BLOCK_SIZE_M, BLOCK_SIZE_N):
     return x.sum(axis=1)
 
 
 @triton.jit
-def _default_combine_op(a, b, **kwargs):
+def _default_combine_op(a, b):
     return a + b
+
+
+@triton.jit
+def _no_reduction_post_op(x, M, N):
+    return x
 
 
 def pack_weights_for_sfc_matmul(
@@ -634,7 +646,8 @@ def sfc_matmul(
             ACCUM_DTYPE=_torch_to_triton_dtype(accum_dtype),
             OUT_DTYPE=_torch_to_triton_dtype(out_dtype),
             HAS_BIAS=bias is not None,
-            POST_OP=post_op or _no_post_op,
+            POST_OP=post_op
+            or (_no_post_op if post_op_arg is None else _no_post_op_with_arg),
             POST_OP_HAS_ARG=post_op_arg is not None,
             REDUCE_LAST_DIM=reduce_last_dim,
             REDUCTION_BLOCK_OP=reduction_block_op or _default_reduction_op,
@@ -656,7 +669,7 @@ def sfc_matmul(
             BLOCK_SIZE_N=BLOCK_SIZE_N,
             REDUCTION_INIT_VAL=reduction_init_val or _default_init_val,
             REDUCTION_COMBINE_OP=reduction_combine_op or _default_combine_op,
-            REDUCTION_POST_OP=reduction_post_op or _no_post_op,
+            REDUCTION_POST_OP=reduction_post_op or _no_reduction_post_op,
             assume_in_bounds=True,
         )
 

--- a/backends/utils/triton_cpu_utils/sfc_matmul.py
+++ b/backends/utils/triton_cpu_utils/sfc_matmul.py
@@ -113,11 +113,18 @@ def _block_pack_kernel(
 # implementation from https://github.com/jakubcerveny/gilbert
 #
 # Each program computes a single output tile with the 2D coordinates derived
-# from the precomputed SFC mapping. If `BLOCKING_FACTOR_K == 1`, then program
-# handles all `BLOCKS_K = K // BLOCK_SIZE_K` blocks along the common dimension,
-# otherwise the program performs a partial accumulation of the K blocks in the
-# half-open interval:
-#    [ ik * (BLOCKS_K // BLOCKING_FACTOR_K), (ik + 1) * (BLOCKS_K // BLOCKING_FACTOR_K) )
+# from the precomputed SFC mapping. If `BLOCKING_FACTOR_K == 1`, then the
+# program handles all
+#   `BLOCKS_K = K // BLOCK_SIZE_K`
+# blocks along the common dimension,  otherwise the program performs a partial
+# accumulation of
+#   `BLOCKS_K_PER_PROG = ⌈BLOCKS_K / BLOCKING_FACTOR_K⌉`
+# blocks, starting at
+#   `ik * BLOCKS_K_PER_PROG`
+# and ending at
+#   `min((ik + 1) * BLOCKS_K_PER_PROG, BLOCKS_K)`
+# The partial accumulation is stored in `c_tmp_ptr` and will be loaded and
+# accumulated in the next iteration of the outer loop.
 @triton.jit
 def _sfc_matmul_kernel(
     a_ptr,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ conflicts = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "65d700b" }
+triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "8769003" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "bc1da11" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ conflicts = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "8769003" }
+triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "c2e0821" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "bc1da11" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ conflicts = [
 [tool.uv.sources]
 torch = { index = "pytorch" }
 triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "c2e0821" }
-lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "bc1da11" }
+lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "0375e8b" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,8 @@ conflicts = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "6a16563" }
-lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "0375e8b" }
+triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "65d700b" }
+lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "bc1da11" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ conflicts = [
 
 [tool.uv.sources]
 torch = { index = "pytorch" }
-triton = { git = "https://github.com/jopperm/triton-cpu.git", rev = "c2e0821" }
+triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "e453f53" }
 lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "0375e8b" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }


### PR DESCRIPTION
Update Triton CPU to include recent upstream bump, the improved lowering of zero-initialized accumulators for vector ISAs.

Upstream Triton disallowed `**kwargs` for `@triton.jit` annotated functions, forcing me to spell out the full parameter lists in the benchmark-specific epilogue and reduction functions.