### PR TITLE
[harness][mlir][xpu] Add level1 attention benchmark

### DIFF
--- a/ai_bench/mlir/pipeline.py
+++ b/ai_bench/mlir/pipeline.py
@@ -9,6 +9,7 @@ from lighthouse.pipeline.descriptor import Descriptor
 from lighthouse.pipeline.driver import BackendDriver
 from lighthouse.schedule.parameters import ScheduleParameters
 from lighthouse.schedule.xegpu import elemwise_schedule
+from lighthouse.schedule.xegpu import fused_attention_schedule
 from lighthouse.schedule.xegpu import mlp_schedule
 from lighthouse.schedule.xegpu import reduction_schedule
 from lighthouse.schedule.xegpu import xegpu_to_binary
@@ -196,6 +197,10 @@ def _compile_xpu_pipeline(
             schedule = reduction_schedule(
                 params=parameters,
                 payload_func_name=payload_func_name,
+            )
+        elif pipeline == "attention":
+            schedule = fused_attention_schedule(
+                params=parameters,
             )
         else:
             raise ValueError(f"Unsupported XPU schedule kind: {pipeline}")

--- a/backends/mlir/xpu/KernelBench/level1/97_ScaledDotProductAttention.py
+++ b/backends/mlir/xpu/KernelBench/level1/97_ScaledDotProductAttention.py
@@ -1,0 +1,16 @@
+import torch
+import torch.nn as nn
+
+
+class Model(nn.Module):
+    mlir_pipeline = "attention"
+    pipeline_parameters = "kb_params_level1-97.json"
+
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(
+        self, Q: torch.Tensor, K: torch.Tensor, V: torch.Tensor
+    ) -> torch.Tensor:
+        out = torch.nn.functional.scaled_dot_product_attention(Q, K, V)
+        return out

--- a/backends/utils/mlir_xpu_utils/kb_params_level1-97.json
+++ b/backends/utils/mlir_xpu_utils/kb_params_level1-97.json
@@ -1,0 +1,30 @@
+[
+    {
+        "layer_kind": "attention",
+        "batch_size": 32,
+        "n_head": 32,
+        "n_ctx": 512,
+        "d_head": 64,
+        "wg_tile": [
+            1,
+            1,
+            128
+        ],
+        "sg_rows": 16,
+        "subgroup_size": 16,
+        "reduction_tile": 64,
+        "q_load_tile": [
+            16,
+            32
+        ],
+        "v_load_tile": [
+            32,
+            32
+        ],
+        "prefetch_tile": [
+            16,
+            32
+        ],
+        "nb_prefetch": 1
+    }
+]

--- a/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
+++ b/problems/specs/KernelBench/level1/97_ScaledDotProductAttention.yaml
@@ -28,3 +28,12 @@ simple-cpu:
       NUM_HEADS: 32
       SEQUENCE_LENGTH: 64
       EMBEDDING_DIMENSION: 128
+
+mlir-gpu-bench:
+  - params: [Q, K, V]
+    dtype: bfloat16
+    dims:
+      BATCH_SIZE: 32
+      NUM_HEADS: 32
+      SEQUENCE_LENGTH: 512
+      EMBEDDING_DIMENSION: 64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ conflicts = [
 [tool.uv.sources]
 torch = { index = "pytorch" }
 triton = { git = "https://github.com/triton-lang/triton-cpu.git", rev = "e453f53" }
-lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "0375e8b" }
+lighthouse = { git = "https://github.com/llvm/lighthouse", rev = "d34fc8a" }
 mlir-python-bindings = { index = "eudsl" }
 triton-cpu-utils = { path = "backends/utils/triton_cpu_utils", editable = true }
 


### PR DESCRIPTION
- Adds `level1/97_ScaledDotProductAttention.py` benchmark to mlir/xpu backend.
- Updates Lighthouse version to pull latest attention schedule updates.